### PR TITLE
Fix multiline history replace in Python Console

### DIFF
--- a/src/gui/python/python_console.cpp
+++ b/src/gui/python/python_console.cpp
@@ -267,7 +267,7 @@ void python_console::replace_current_command(const QString& new_command)
 {
     QTextCursor cursor = textCursor();
     cursor.setPosition(m_prompt_end_position);
-    cursor.movePosition(QTextCursor::EndOfLine, QTextCursor::KeepAnchor);
+    cursor.movePosition(QTextCursor::End, QTextCursor::KeepAnchor);
     cursor.insertText(new_command);
 }
 


### PR DESCRIPTION
Change cursor target position for replace to QTextCursor::End instead of QTextCursor::EndOfLine. This fixes a bug where pressing the arrow keys to navigate through the command history while a multi-line command was in the prompt caused only the first line to be replaced correctly.