### PR TITLE
Fix python editor dialogs reset global file name

### DIFF
--- a/src/gui/python/python_editor.cpp
+++ b/src/gui/python/python_editor.cpp
@@ -314,11 +314,22 @@ void python_editor::handle_action_save_file()
     QString title = "Save File";
     QString text  = "Python Scripts(*.py)";
 
+    QString selected_file_name;
+
     if (m_file_name.isEmpty())
     {
-        m_file_name = QFileDialog::getSaveFileName(nullptr, title, QDir::currentPath(), text, nullptr, QFileDialog::DontUseNativeDialog);
+        selected_file_name = QFileDialog::getSaveFileName(nullptr, title, QDir::currentPath(), text, nullptr, QFileDialog::DontUseNativeDialog);
+        if (selected_file_name.isEmpty())
+        {
+            return;
+        }
     }
-    std::ofstream out(m_file_name.toStdString(), std::ios::out);
+    else
+    {
+        selected_file_name = m_file_name;
+    }
+
+    std::ofstream out(selected_file_name.toStdString(), std::ios::out);
 
     if (!out.is_open())
     {
@@ -326,6 +337,9 @@ void python_editor::handle_action_save_file()
     }
     out << m_editor_widget->toPlainText().toStdString();
     out.close();
+
+    // remember target file path
+    m_file_name = selected_file_name;
 }
 
 void python_editor::handle_action_run()

--- a/src/gui/python/python_editor.cpp
+++ b/src/gui/python/python_editor.cpp
@@ -285,19 +285,22 @@ void python_editor::handle_action_open_file()
     QString title = "Open File";
     QString text  = "Python Scripts(*.py)";
 
-    m_file_name = QFileDialog::getOpenFileName(nullptr, title, QDir::currentPath(), text, nullptr, QFileDialog::DontUseNativeDialog);
+    QString new_file_name = QFileDialog::getOpenFileName(nullptr, title, QDir::currentPath(), text, nullptr, QFileDialog::DontUseNativeDialog);
 
-    if (m_file_name.isEmpty())
+    if (new_file_name.isEmpty())
     {
         return;
     }
 
-    std::ifstream file(m_file_name.toStdString(), std::ios::in);
+    std::ifstream file(new_file_name.toStdString(), std::ios::in);
 
     if (!file.is_open())
     {
         return;
     }
+    
+    // make file active
+    m_file_name = new_file_name;
 
     m_editor_widget->clear();
     std::string f((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());


### PR DESCRIPTION
Store selected file names in open/save operations in the Python editor in a local variable until the file path and successful access have been verified. This fixes three bugs causing a reset of the path of the currently open file and being unable to save after a failed write.