### PR TITLE
Fix bad python binding for "gates" property of "module"

### DIFF
--- a/src/python-binding/python_definitions.cpp
+++ b/src/python-binding/python_definitions.cpp
@@ -1186,7 +1186,7 @@ A module output net is either a global output of the netlist or has a destinatio
 :returns: The set of module output nets.
 :rtype: set(hal_py.module)
 )")
-        .def_property_readonly("gates", &module::get_gates, R"(
+        .def_property_readonly("gates", [](module& n) -> std::set<std::shared_ptr<gate>> { return n.get_gates(); }, R"(
 Gets all gates of the module.
 
 :returns: A set of gates.


### PR DESCRIPTION
Replace the binding of the "gates" read-only property of "hal_py.module" to "module::get_gates" from function pointer to lambda. This fixes a bug where default arguments of the get_gates function would be ignored and not used, causing a function signature mismatch and crash of the python script.

The bug causes this error message for this minimal example:
```python
netlist.get_top_module().gates
```
```
TypeError: (): incompatible function arguments. The following argument types are supported:
    1. (arg0: hal_py.module, arg1: str, arg2: str, arg3: bool) -> Set[hal_py.gate]

Invoked with: <hal_py.module object at 0x7fe5d70b2a40>
```