### PR TITLE
Feature/py-open-multiple-files

### DIFF
--- a/include/gui/python/python_editor.h
+++ b/include/gui/python/python_editor.h
@@ -164,6 +164,8 @@ private:
     int m_new_file_counter;
 
     long m_last_click_time;
+
+    QString m_last_opened_path;
 };
 
 #endif    // PYTHON_WIDGET_H

--- a/src/gui/python/python_editor.cpp
+++ b/src/gui/python/python_editor.cpp
@@ -33,6 +33,8 @@ python_editor::python_editor(QWidget* parent)
     m_new_file_counter = 0;
     m_last_click_time  = 0;
 
+    m_last_opened_path = QDir::currentPath();
+
     m_tab_widget = new QTabWidget(this);
     m_tab_widget->setTabsClosable(true);
     m_tab_widget->setMovable(true);
@@ -293,7 +295,7 @@ void python_editor::handle_action_open_file()
     QString title = "Open File";
     QString text  = "Python Scripts(*.py)";
 
-    QStringList file_names = QFileDialog::getOpenFileNames(nullptr, title, QDir::currentPath(), text, nullptr, QFileDialog::DontUseNativeDialog);
+    QStringList file_names = QFileDialog::getOpenFileNames(nullptr, title, m_last_opened_path, text, nullptr, QFileDialog::DontUseNativeDialog);
 
     if (file_names.isEmpty())
     {
@@ -324,6 +326,8 @@ void python_editor::handle_action_open_file()
         handle_action_new_tab();
         tab_load_file(m_tab_widget->count() - 1, file_name);
     }
+
+    m_last_opened_path = QFileInfo(file_names.last()).absolutePath();
 }
 
 void python_editor::tab_load_file(u32 index, QString file_name)

--- a/src/gui/python/python_editor.cpp
+++ b/src/gui/python/python_editor.cpp
@@ -293,34 +293,37 @@ void python_editor::handle_action_open_file()
     QString title = "Open File";
     QString text  = "Python Scripts(*.py)";
 
-    QString file_name = QFileDialog::getOpenFileName(nullptr, title, QDir::currentPath(), text, nullptr, QFileDialog::DontUseNativeDialog);
+    QStringList file_names = QFileDialog::getOpenFileNames(nullptr, title, QDir::currentPath(), text, nullptr, QFileDialog::DontUseNativeDialog);
 
-    if (file_name.isEmpty())
+    if (file_names.isEmpty())
     {
         return;
     }
 
-    for (int i = 0; i < m_tab_widget->count(); ++i)
+    for(auto file_name : file_names)
     {
-        auto editor = dynamic_cast<python_code_editor*>(m_tab_widget->widget(i));
-        if (editor->get_file_name() == file_name)
+        for (int i = 0; i < m_tab_widget->count(); ++i)
         {
-            m_tab_widget->setCurrentIndex(i);
-
-            if (editor->document()->isModified())
+            auto editor = dynamic_cast<python_code_editor*>(m_tab_widget->widget(i));
+            if (editor->get_file_name() == file_name)
             {
-                if (QMessageBox::question(editor, "Script has unsaved changes", "Do you want to reload the file from disk? Unsaved changes are lost.", QMessageBox::Yes | QMessageBox::No)
-                    == QMessageBox::Yes)
-                {
-                    tab_load_file(i, file_name);
-                }
-            }
-            return;
-        }
-    }
+                m_tab_widget->setCurrentIndex(i);
 
-    handle_action_new_tab();
-    tab_load_file(m_tab_widget->count() - 1, file_name);
+                if (editor->document()->isModified())
+                {
+                    if (QMessageBox::question(editor, "Script has unsaved changes", "Do you want to reload the file from disk? Unsaved changes are lost.", QMessageBox::Yes | QMessageBox::No)
+                        == QMessageBox::Yes)
+                    {
+                        tab_load_file(i, file_name);
+                    }
+                }
+                return;
+            }
+        }
+
+        handle_action_new_tab();
+        tab_load_file(m_tab_widget->count() - 1, file_name);
+    }
 }
 
 void python_editor::tab_load_file(u32 index, QString file_name)


### PR DESCRIPTION
The python editor now allows opening multiple files at once. Also the path of the last opened file will be remembered and the next time the user wants to open a file this path is presented to the user first.

Adds features requested in #141 thus closing #141.