### PR TITLE
Feature/gate ancestors

### DIFF
--- a/include/gui/gui_utils/netlist.h
+++ b/include/gui/gui_utils/netlist.h
@@ -31,8 +31,8 @@
 
 namespace gui_utility
 {
-    std::shared_ptr<module> common_ancestor(std::unordered_set<std::shared_ptr<module>> modules, std::unordered_set<std::shared_ptr<gate>> gates);
-    std::shared_ptr<module> common_ancestor_two(std::shared_ptr<module> m1, std::shared_ptr<module> m2);
+    std::shared_ptr<module> lowest_common_ancestor(std::unordered_set<std::shared_ptr<module>> modules, std::unordered_set<std::shared_ptr<gate>> gates);
+    std::shared_ptr<module> lowest_common_ancestor(std::shared_ptr<module> m1, std::shared_ptr<module> m2);
 }
 
 #endif // NETLIST_UTIL_H

--- a/include/gui/gui_utils/netlist.h
+++ b/include/gui/gui_utils/netlist.h
@@ -1,0 +1,38 @@
+//  MIT License
+//
+//  Copyright (c) 2019 Ruhr-University Bochum, Germany, Chair for Embedded Security. All Rights reserved.
+//  Copyright (c) 2019 Marc Fyrbiak, Sebastian Wallat, Max Hoffmann ("ORIGINAL AUTHORS"). All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+#ifndef NETLIST_UTIL_H
+#define NETLIST_UTIL_H
+
+#include "netlist/gate.h"
+#include "netlist/module.h"
+
+#include <unordered_set>
+
+namespace gui_utility
+{
+    std::shared_ptr<module> common_ancestor(std::unordered_set<std::shared_ptr<module>> modules, std::unordered_set<std::shared_ptr<gate>> gates);
+    std::shared_ptr<module> common_ancestor_two(std::shared_ptr<module> m1, std::shared_ptr<module> m2);
+}
+
+#endif // NETLIST_UTIL_H

--- a/src/gui/graph_widget/graph_graphics_view.cpp
+++ b/src/gui/graph_widget/graph_graphics_view.cpp
@@ -127,10 +127,6 @@ void graph_graphics_view::handle_move_action(QAction* action)
 
 void graph_graphics_view::handle_move_new_action()
 {
-    bool ok;
-    QString name = QInputDialog::getText(nullptr, "", "Module Name:", QLineEdit::Normal, "", &ok);
-    if (!ok || name.isEmpty())
-        return;
     std::unordered_set<std::shared_ptr<gate>> gate_objs;
     std::unordered_set<std::shared_ptr<module>> module_objs;
     for (const auto& id : g_selection_relay.m_selected_gates)
@@ -141,8 +137,16 @@ void graph_graphics_view::handle_move_new_action()
     {
         module_objs.insert(g_netlist->get_module_by_id(id));
     }
-    std::shared_ptr<module> m = g_netlist->create_module(g_netlist->get_unique_module_id(), name.toStdString(),
-        gui_utility::common_ancestor(module_objs, gate_objs));
+    std::shared_ptr<module> parent = gui_utility::common_ancestor(module_objs, gate_objs);
+    QString parent_name = QString::fromStdString(parent->get_name());
+    bool ok;
+    QString name = QInputDialog::getText(nullptr, "",
+        "New module will be created under \"" + parent_name + "\"\nModule Name:",
+        QLineEdit::Normal, "", &ok);
+    if (!ok || name.isEmpty())
+        return;
+    std::shared_ptr<module> m = g_netlist->create_module(g_netlist->get_unique_module_id(),
+        name.toStdString(), parent);
 
     for (const auto& id : g_selection_relay.m_selected_gates)
     {

--- a/src/gui/graph_widget/graph_graphics_view.cpp
+++ b/src/gui/graph_widget/graph_graphics_view.cpp
@@ -137,7 +137,7 @@ void graph_graphics_view::handle_move_new_action()
     {
         module_objs.insert(g_netlist->get_module_by_id(id));
     }
-    std::shared_ptr<module> parent = gui_utility::common_ancestor(module_objs, gate_objs);
+    std::shared_ptr<module> parent = gui_utility::lowest_common_ancestor(module_objs, gate_objs);
     QString parent_name = QString::fromStdString(parent->get_name());
     bool ok;
     QString name = QInputDialog::getText(nullptr, "",

--- a/src/gui/graph_widget/graph_graphics_view.cpp
+++ b/src/gui/graph_widget/graph_graphics_view.cpp
@@ -15,6 +15,7 @@
 #include "gui/graph_widget/items/standard_graphics_net.h"
 #include "gui/graph_widget/items/utility_items/drag_shadow_gate.h"
 #include "gui/gui_globals.h"
+#include "gui/gui_utils/netlist.h"
 #include "netlist/gate.h"
 #include "netlist/module.h"
 #include "netlist/net.h"
@@ -130,9 +131,18 @@ void graph_graphics_view::handle_move_new_action()
     QString name = QInputDialog::getText(nullptr, "", "Module Name:", QLineEdit::Normal, "", &ok);
     if (!ok || name.isEmpty())
         return;
-    // There is no easy way to allow the user to create a submodule on the fly here,
-    // so this creates a new module under the top-module.
-    std::shared_ptr<module> m = g_netlist->create_module(g_netlist->get_unique_module_id(), name.toStdString(), g_netlist->get_top_module());
+    std::unordered_set<std::shared_ptr<gate>> gate_objs;
+    std::unordered_set<std::shared_ptr<module>> module_objs;
+    for (const auto& id : g_selection_relay.m_selected_gates)
+    {
+        gate_objs.insert(g_netlist->get_gate_by_id(id));
+    }
+    for (const auto& id : g_selection_relay.m_selected_modules)
+    {
+        module_objs.insert(g_netlist->get_module_by_id(id));
+    }
+    std::shared_ptr<module> m = g_netlist->create_module(g_netlist->get_unique_module_id(), name.toStdString(),
+        gui_utility::common_ancestor(module_objs, gate_objs));
 
     for (const auto& id : g_selection_relay.m_selected_gates)
     {

--- a/src/gui/gui_utils/netlist.cpp
+++ b/src/gui/gui_utils/netlist.cpp
@@ -54,6 +54,9 @@ namespace gui_utility
             std::shared_ptr<module> m2 = *modules.begin();
             modules.erase(m2);
             std::shared_ptr<module> common = lowest_common_ancestor(m1, m2);
+            // if we hit the top module, we can stop searching
+            if (common->get_parent_module() == nullptr)
+                return common;
             modules.insert(common);
         }
         // the remaining module is the lowest common ancestor of all elements

--- a/src/gui/gui_utils/netlist.cpp
+++ b/src/gui/gui_utils/netlist.cpp
@@ -1,0 +1,63 @@
+#include "gui_utils/netlist.h"
+#include "gui/gui_globals.h"
+
+#include "netlist/gate.h"
+#include "netlist/module.h"
+
+// TODO Consider these for moving into the core if they are useful
+
+#include <unordered_set>
+
+namespace gui_utility
+{
+
+    std::shared_ptr<module> common_ancestor_two(std::shared_ptr<module> m1, std::shared_ptr<module> m2)
+    {
+        std::unordered_set<std::shared_ptr<module>> common;
+        common.insert(m1);
+        common.insert(m2);
+        while (true)
+        {
+            std::shared_ptr<module> p1 = m1->get_parent_module();
+            if (common.find(p1) != common.end())
+                return p1;
+            common.insert(p1);
+            m1 = p1;
+            std::shared_ptr<module> p2 = m2->get_parent_module();
+            if (common.find(p2) != common.end())
+                return p2;
+            common.insert(p2);
+            m2 = p2;
+        }
+    }
+
+    std::shared_ptr<module> common_ancestor(std::unordered_set<std::shared_ptr<module>> modules, std::unordered_set<std::shared_ptr<gate>> gates)
+    {
+        if (modules.empty() && gates.empty())
+        {
+            return nullptr;
+        }
+        // resolve all gates to their parent modules, since we don't want to work with gates
+        while(!gates.empty())
+        {
+            std::shared_ptr<gate> g = *gates.begin();
+            gates.erase(g);
+            std::shared_ptr<module> m = g->get_module();
+            modules.insert(m);
+        }
+        // pick two modules and resolve them to their lowest common ancestor,
+        // insert that back into the set and loop until only 1 module remains
+        while(modules.size() >= 2)
+        {
+            std::shared_ptr<module> m1 = *modules.begin();
+            modules.erase(m1);
+            std::shared_ptr<module> m2 = *modules.begin();
+            modules.erase(m2);
+            std::shared_ptr<module> common = common_ancestor_two(m1, m2);
+            modules.insert(common);
+        }
+        // the remaining module is the lowest common ancestor of all elements
+        return *modules.begin();
+    }
+
+} // namespace gui_utility

--- a/src/gui/gui_utils/netlist.cpp
+++ b/src/gui/gui_utils/netlist.cpp
@@ -11,7 +11,7 @@
 namespace gui_utility
 {
 
-    std::shared_ptr<module> common_ancestor_two(std::shared_ptr<module> m1, std::shared_ptr<module> m2)
+    std::shared_ptr<module> lowest_common_ancestor(std::shared_ptr<module> m1, std::shared_ptr<module> m2)
     {
         std::unordered_set<std::shared_ptr<module>> common;
         common.insert(m1);
@@ -31,7 +31,7 @@ namespace gui_utility
         }
     }
 
-    std::shared_ptr<module> common_ancestor(std::unordered_set<std::shared_ptr<module>> modules, std::unordered_set<std::shared_ptr<gate>> gates)
+    std::shared_ptr<module> lowest_common_ancestor(std::unordered_set<std::shared_ptr<module>> modules, std::unordered_set<std::shared_ptr<gate>> gates)
     {
         if (modules.empty() && gates.empty())
         {
@@ -53,7 +53,7 @@ namespace gui_utility
             modules.erase(m1);
             std::shared_ptr<module> m2 = *modules.begin();
             modules.erase(m2);
-            std::shared_ptr<module> common = common_ancestor_two(m1, m2);
+            std::shared_ptr<module> common = lowest_common_ancestor(m1, m2);
             modules.insert(common);
         }
         // the remaining module is the lowest common ancestor of all elements


### PR DESCRIPTION
When a module is created via the context menu on a selection of gates and modules, the new module is currently created under the top module. This breaks module hierarchy.

This PR adds an algorithm to find the lowest common ancestor in the module tree and places newly created modules at the correct place in the module hierarchy using that algorithm.

The user is informed about HAL's decision on where to place the module when the input dialog for the new module's name pops up.