### PR TITLE
Fix module color change issues

### DIFF
--- a/include/gui/graph_widget/graph_context_manager.h
+++ b/include/gui/graph_widget/graph_context_manager.h
@@ -32,6 +32,7 @@ public:
     //void handle_module_created(const std::shared_ptr<module> m) const;
     void handle_module_removed(const std::shared_ptr<module> m);
     void handle_module_name_changed(const std::shared_ptr<module> m) const;
+    void handle_module_color_changed(const std::shared_ptr<module> m) const;
     //void handle_module_parent_changed(const std::shared_ptr<module> m) const;
     void handle_module_submodule_added(const std::shared_ptr<module> m, const u32 added_module) const;
     void handle_module_submodule_removed(const std::shared_ptr<module> m, const u32 removed_module);

--- a/src/gui/graph_widget/graph_context_manager.cpp
+++ b/src/gui/graph_widget/graph_context_manager.cpp
@@ -69,6 +69,20 @@ void graph_context_manager::handle_module_name_changed(const std::shared_ptr<mod
             context->schedule_scene_update();
 }
 
+void graph_context_manager::handle_module_color_changed(const std::shared_ptr<module> m) const
+{
+    auto gates = m->get_gates();
+    QSet<u32> gateIDs;
+    for (auto g : gates)
+        gateIDs.insert(g->get_id());
+    for (graph_context* context : m_graph_contexts)
+        if (context->modules().contains(m->get_id()) // contains module
+            || context->gates().intersects(gateIDs)) // contains gate from module
+            context->schedule_scene_update();
+    // a context can contain a gate from a module if it is showing the module
+    // or if it's showing a parent and the module is unfolded
+}
+
 void graph_context_manager::handle_module_submodule_added(const std::shared_ptr<module> m, const u32 added_module) const
 {
     for (graph_context* context : m_graph_contexts)

--- a/src/gui/graph_widget/graph_context_manager.cpp
+++ b/src/gui/graph_widget/graph_context_manager.cpp
@@ -115,6 +115,7 @@ void graph_context_manager::handle_module_gate_assigned(const std::shared_ptr<mo
 void graph_context_manager::handle_module_gate_removed(const std::shared_ptr<module> m, const u32 removed_gate)
 {
     for (graph_context* context : m_graph_contexts)
+    {
         if (context->is_showing_module(m->get_id(), {}, {}, {}, {removed_gate}))
         {
             context->remove({}, {removed_gate});
@@ -123,6 +124,11 @@ void graph_context_manager::handle_module_gate_removed(const std::shared_ptr<mod
                 delete_graph_context(context);
             }
         }
+        // if a module is unfolded, then the gate is not deleted from the view
+        // but the color of the gate changes to its new parent's color
+        else if (context->gates().contains(removed_gate))
+            context->schedule_scene_update();
+    }
 }
 
 void graph_context_manager::handle_gate_name_changed(const std::shared_ptr<gate> g) const

--- a/src/gui/netlist_relay/netlist_relay.cpp
+++ b/src/gui/netlist_relay/netlist_relay.cpp
@@ -89,6 +89,10 @@ void netlist_relay::debug_change_module_color(const u32 id)
     m_module_colors.insert(id, color);
     m_module_model->update_module(id);
 
+    // Since color is our overlay over the netlist data, no event is
+    // automatically fired. We need to take care of that ourselves here.
+    g_graph_context_manager.handle_module_color_changed(m);
+
     Q_EMIT module_color_changed(m);
 }
 


### PR DESCRIPTION
This fixes the following bugs:

- When a module's color is changed, the graph view holding that module or any of its gates is not updated
- When a module is deleted while in unfolded state in a graph view, the child gates' color does not change to the new parent's color