### PR TITLE
Unify event sequences in the core

### DIFF
--- a/src/gui/netlist_relay/netlist_relay.cpp
+++ b/src/gui/netlist_relay/netlist_relay.cpp
@@ -237,7 +237,6 @@ void netlist_relay::relay_module_event(module_event_handler::event ev, std::shar
             if (object->get_parent_module() != nullptr)
             {
                 m_module_colors.insert(object->get_id(), gui_utility::get_random_color());
-                m_module_model->add_module(object->get_id(), object->get_parent_module()->get_id());
             }
 
             Q_EMIT module_created(object);
@@ -270,9 +269,6 @@ void netlist_relay::relay_module_event(module_event_handler::event ev, std::shar
         {
             //< no associated_data
 
-            m_module_model->remove_module(object->get_id());
-            m_module_model->add_module(object->get_id(), object->get_parent_module()->get_id());
-
             Q_EMIT module_parent_changed(object);
             break;
         }
@@ -280,7 +276,7 @@ void netlist_relay::relay_module_event(module_event_handler::event ev, std::shar
         {
             //< associated_data = id of added module
 
-            //m_module_model->add_module(associated_data, object->get_id());
+            m_module_model->add_module(associated_data, object->get_id());
 
             g_graph_context_manager.handle_module_submodule_added(object, associated_data);
 

--- a/src/netlist/netlist_internal_manager.cpp
+++ b/src/netlist/netlist_internal_manager.cpp
@@ -419,10 +419,12 @@ bool netlist_internal_manager::delete_module(std::shared_ptr<module> to_remove)
         to_remove->m_parent->m_submodules_map[sm->get_id()] = sm;
         to_remove->m_parent->m_submodules_set.insert(sm);
 
+        module_event_handler::notify(module_event_handler::event::submodule_removed, sm->get_parent_module(), sm->get_id());
+
         sm->m_parent = to_remove->m_parent;
 
-        module_event_handler::notify(module_event_handler::event::submodule_added, to_remove->m_parent, sm->get_id());
         module_event_handler::notify(module_event_handler::event::parent_changed, sm, 0);
+        module_event_handler::notify(module_event_handler::event::submodule_added, to_remove->m_parent, sm->get_id());
     }
 
     // remove module from parent


### PR DESCRIPTION
Deleting modules with child nodes and moving modules into their
own children produced different event sequences that make different
assumptions, so the GUI crashes on either one or the other.
This unifies the events by deciding we'll temporarily accept nodes
with no parent until a movement or deletion has completed.