### PR TITLE
Add module tree sorting, fix module tree init bug, optimize sorting algos

### DIFF
--- a/include/gui/gui_utils/sort.h
+++ b/include/gui/gui_utils/sort.h
@@ -38,6 +38,9 @@ namespace gui_utility
     bool lexical_order_compare(const QString& a, const QString& b);
     int numeric_string_compare(QString a_num, QString b_num);
 
+    // convenience method to select an algoritm
+    int compare(sort_mechanism mechanism, QString a, QString b);
+
 } // namespace gui_utility
 
 #endif // SORT_UTIL_H

--- a/include/gui/module_model/module_model.h
+++ b/include/gui/module_model/module_model.h
@@ -27,6 +27,8 @@
 
 #include "def.h"
 
+#include "gui/gui_utils/sort.h"
+
 #include <QAbstractItemModel>
 #include <QModelIndex>
 #include <QVariant>
@@ -61,10 +63,15 @@ public:
     void remove_module(const u32 id);
     void update_module(const u32 id);
 
+private Q_SLOTS:
+    void handle_global_setting_changed(void* sender, const QString& key, const QVariant& value);
+
 private:
     module_item* m_top_module_item;
 
     QMap<u32, module_item*> m_module_items;
+
+    gui_utility::sort_mechanism m_sort_mechanism;
 };
 
 #endif // MODULE_MODEL_H

--- a/include/gui/module_model/module_model.h
+++ b/include/gui/module_model/module_model.h
@@ -28,6 +28,9 @@
 #include "def.h"
 
 #include "gui/gui_utils/sort.h"
+#include "netlist/module.h"
+
+#include <set>
 
 #include <QAbstractItemModel>
 #include <QModelIndex>
@@ -60,6 +63,7 @@ public:
     void clear();
 
     void add_module(const u32 id, const u32 parent_module);
+    void add_recursively(std::set<std::shared_ptr<module>> modules);
     void remove_module(const u32 id);
     void update_module(const u32 id);
 

--- a/src/gui/gui_utils/sort.cpp
+++ b/src/gui/gui_utils/sort.cpp
@@ -2,7 +2,7 @@
 
 #include "def.h"
 
-#include <QDebug>
+#include <assert.h>
 
 namespace gui_utility
 {
@@ -92,6 +92,18 @@ namespace gui_utility
             b_num = b_num.rightJustified(a_num.size(), '0');
         }
         return a_num.compare(b_num);
+    }
+
+    int compare(sort_mechanism mechanism, QString a, QString b)
+    {
+        switch(mechanism)
+        {
+        case lexical:
+            return lexical_order_compare(a, b);
+        case natural:
+            return natural_order_compare(a, b);
+        }
+        assert(false);
     }
 
 

--- a/src/gui/gui_utils/sort.cpp
+++ b/src/gui/gui_utils/sort.cpp
@@ -36,9 +36,9 @@ namespace gui_utility
                 if (number_mode)
                 {
                     int diff = numeric_string_compare(a_num, b_num);
-                    if (diff) // keep looking if both numbers are equal
+                    if (diff != 0) // keep looking if both numbers are equal
                     {
-                        return diff > 0;
+                        return diff < 0;
                     }
                     // reset number cache
                     a_num.clear();
@@ -49,7 +49,7 @@ namespace gui_utility
                 }
                 else if (*a_it != *b_it)
                 {
-                    return *a_it > *b_it;
+                    return *a_it < *b_it;
                 }
                 else
                 {
@@ -65,15 +65,15 @@ namespace gui_utility
             int diff = numeric_string_compare(a_num, b_num);
             if (diff) // keep looking if both numbers are equal
             {
-                return diff > 0;
+                return diff < 0;
             }
         }
-        return b_it->isNull(); // is b shorter than a?
+        return a_it->isNull(); // is a shorter than b?
     }
 
     bool lexical_order_compare(const QString& a, const QString& b)
     {
-        return a > b;
+        return a < b;
     }
 
     int numeric_string_compare(QString a_num, QString b_num)

--- a/src/gui/module_model/module_model.cpp
+++ b/src/gui/module_model/module_model.cpp
@@ -239,7 +239,7 @@ void module_model::add_module(const u32 id, const u32 parent_module)
 
     while (row < parent->childCount())
     {
-        if (!gui_utility::compare(m_sort_mechanism, item->name(), parent->child(row)->name()))
+        if (gui_utility::compare(m_sort_mechanism, item->name(), parent->child(row)->name()))
             break;
         else
             ++row;

--- a/src/gui/selection_details_widget/tree_navigation/tree_module_model.cpp
+++ b/src/gui/selection_details_widget/tree_navigation/tree_module_model.cpp
@@ -164,12 +164,12 @@ void tree_module_model::update(u32 module_id)
     {
         case gui_utility::sort_mechanism::lexical:
             std::sort(sorted_gates.begin(), sorted_gates.end(), [](std::shared_ptr<gate> g1, std::shared_ptr<gate> g2){
-                return (!gui_utility::lexical_order_compare(QString::fromStdString(g1->get_name()).toLower(), QString::fromStdString(g2->get_name()).toLower()));
+                return (gui_utility::lexical_order_compare(QString::fromStdString(g1->get_name()).toLower(), QString::fromStdString(g2->get_name()).toLower()));
             });
             break;
         case gui_utility::sort_mechanism::natural:
             std::sort(sorted_gates.begin(), sorted_gates.end(), [](std::shared_ptr<gate> g1, std::shared_ptr<gate> g2){
-                return (!gui_utility::natural_order_compare(QString::fromStdString(g1->get_name()).toLower(), QString::fromStdString(g2->get_name()).toLower()));
+                return (gui_utility::natural_order_compare(QString::fromStdString(g1->get_name()).toLower(), QString::fromStdString(g2->get_name()).toLower()));
             });
             break;
     }
@@ -179,12 +179,12 @@ void tree_module_model::update(u32 module_id)
     {
         case gui_utility::sort_mechanism::lexical:
             std::sort(sorted_nets.begin(), sorted_nets.end(), [](std::shared_ptr<net> n1, std::shared_ptr<net> n2){
-                return (!gui_utility::lexical_order_compare(QString::fromStdString(n1->get_name()).toLower(), QString::fromStdString(n2->get_name()).toLower()));
+                return (gui_utility::lexical_order_compare(QString::fromStdString(n1->get_name()).toLower(), QString::fromStdString(n2->get_name()).toLower()));
             });
             break;
         case gui_utility::sort_mechanism::natural:
             std::sort(sorted_nets.begin(), sorted_nets.end(), [](std::shared_ptr<net> n1, std::shared_ptr<net> n2){
-                return (!gui_utility::natural_order_compare(QString::fromStdString(n1->get_name()).toLower(), QString::fromStdString(n2->get_name()).toLower()));
+                return (gui_utility::natural_order_compare(QString::fromStdString(n1->get_name()).toLower(), QString::fromStdString(n2->get_name()).toLower()));
             });
             break;
     }


### PR DESCRIPTION
Module tree can now be sorted using lexical and natural sorting.

Module tree will no longer crash when initializing with a submodule of a name that comes before the name of its parent alphabetically.

Fix some bad code style in the sorting algorithms.