### PR TITLE
fix in Verfolg parser, cleanup in liberty parser

### DIFF
--- a/src/netlist/gate_library/gate_library_parser/gate_library_parser_liberty.cpp
+++ b/src/netlist/gate_library/gate_library_parser/gate_library_parser_liberty.cpp
@@ -504,16 +504,16 @@ std::shared_ptr<gate_type> gate_library_parser_liberty::construct_gate_type()
 
         for (auto& [pin_name, bf] : m_current_cell.functions)
         {
-            auto func = boolean_function::from_string(bf);
-            auto pins = gt->get_input_pins();
-            auto vars = func.get_variables();
+            auto func       = boolean_function::from_string(bf);
+            auto input_pins = gt->get_input_pins();
+            auto vars       = func.get_variables();
 
             // verify that all variables correspond to actual input pins
             for (const auto& var : vars)
             {
-                if (std::find(pins.begin(), pins.end(), var) == pins.end())
+                if (std::find(input_pins.begin(), input_pins.end(), var) == input_pins.end())
                 {
-                    log_error("netlist", "variable '{}' of boolean function '{}' of gate type '{}' does not match any input pin.", var, func.to_string(), gt->get_name());
+                    log_error("netlist", "variable '{}' of boolean function '{}' for pin '{}' of gate type '{}' does not match any input pin.", var, func.to_string(), pin_name, gt->get_name());
                     return nullptr;
                 }
             }

--- a/src/netlist/hdl_parser/hdl_parser_verilog.cpp
+++ b/src/netlist/hdl_parser/hdl_parser_verilog.cpp
@@ -147,7 +147,7 @@ std::shared_ptr<netlist> hdl_parser_verilog::parse(const std::string& gate_libra
 
 bool hdl_parser_verilog::tokenize()
 {
-    std::string delimiters = ",()[]\\#: ;=.";
+    std::string delimiters = ",()[]{}\\#: ;=.";
     std::string current_token;
     u32 line_number = 0;
 


### PR DESCRIPTION
- fixed a bug in the Verflog parser that prevented the correct handling of assignments like "A = {B, C}"
- some cleanup in the Liberty parser