### PR TITLE
fixed value assignment parsing bug in verliog parser

### DIFF
--- a/src/netlist/hdl_parser/hdl_parser_verilog.cpp
+++ b/src/netlist/hdl_parser/hdl_parser_verilog.cpp
@@ -248,23 +248,29 @@ bool hdl_parser_verilog::parse_entity_definiton()
 
     m_token_stream.consume(";", true);
 
-    while (m_token_stream.peek() != "endmodule")
+    auto next_token = m_token_stream.peek();
+    while (next_token != "endmodule")
     {
-        if (m_token_stream.peek() == "input" || m_token_stream.peek() == "output")
+        if (next_token == "input" || next_token == "output")
         {
             if (!parse_port_definition(e))
             {
                 return false;
             }
         }
-        else if (m_token_stream.peek() == "wire")
+        else if (next_token == "inout")
+        {
+            log_error("hdl_parser", "entity '{}', line {} : direction 'inout' unkown", e.name, e.line_number);
+            return false;
+        }
+        else if (next_token == "wire")
         {
             if (!parse_signal_definition(e))
             {
                 return false;
             }
         }
-        else if (m_token_stream.peek() == "assign")
+        else if (next_token == "assign")
         {
             if (!parse_assign(e))
             {
@@ -278,6 +284,8 @@ bool hdl_parser_verilog::parse_entity_definiton()
                 return false;
             }
         }
+
+        next_token = m_token_stream.peek();
     }
 
     m_token_stream.consume("endmodule", true);
@@ -365,7 +373,7 @@ bool hdl_parser_verilog::parse_assign(entity& e)
     m_token_stream.consume(";", true);
 
     auto left_parts  = get_assignment_signals(left_str, e, false);
-    auto right_parts = get_assignment_signals(right_str, e, false);
+    auto right_parts = get_assignment_signals(right_str, e, true);
 
     if (left_parts.empty() || right_parts.empty())
     {


### PR DESCRIPTION
Fixed a bug in the Verilog parser that rendered it unable to assign values to wires or ports. Added more meaningful output for (currently not supported) "inout" ports.