### PR TITLE
Add Python GUI API

### DIFF
--- a/include/gui/gui_api/gui_api.h
+++ b/include/gui/gui_api/gui_api.h
@@ -1,0 +1,82 @@
+#ifndef GUI_API_H
+#define GUI_API_H
+
+#include "netlist/gate.h"
+#include "netlist/net.h"
+#include "netlist/module.h"
+
+#include <vector>
+#include <tuple>
+
+class gui_api
+{
+public:
+    gui_api();
+    ~gui_api();
+
+    std::vector<u32> get_selected_gate_ids();
+    std::vector<u32> get_selected_net_ids();
+    std::vector<u32> get_selected_module_ids();
+    std::tuple<std::vector<u32>, std::vector<u32>, std::vector<u32>> get_selected_item_ids();
+
+    std::vector<std::shared_ptr<gate>> get_selected_gates();
+    std::vector<std::shared_ptr<net>> get_selected_nets();
+    std::vector<std::shared_ptr<module>> get_selected_modules();
+    std::tuple<std::vector<std::shared_ptr<gate>>, std::vector<std::shared_ptr<net>>, std::vector<std::shared_ptr<module>>> get_selected_items();
+
+    void print_selected_gates();
+    void print_selected_nets();
+    void print_selected_modules();
+    void print_selected_items();
+
+    void select_gate(u32 gate_id, bool clear_current_selection = true);
+    void select_gate(std::vector<u32> gate_ids, bool clear_current_selection = true);
+    void select_gate(std::shared_ptr<gate> gate, bool clear_current_selection = true);
+    void select_gate(std::vector<std::shared_ptr<gate>> gates, bool clear_current_selection = true);
+
+    void select_net(u32 net_id, bool clear_current_selection = true);
+    void select_net(std::vector<u32> net_ids, bool clear_current_selection = true);
+    void select_net(std::shared_ptr<net> net, bool clear_current_selection = true);
+    void select_net(std::vector<std::shared_ptr<net>> nets, bool clear_current_selection = true);
+
+    void select_module(u32 module_id, bool clear_current_selection = true);  
+    void select_module(std::vector<u32> module_ids, bool clear_current_selection = true);
+    void select_module(std::shared_ptr<module> module, bool clear_current_selection = true);
+    void select_module(std::vector<std::shared_ptr<module>> modules, bool clear_current_selection = true);
+
+    void select(std::shared_ptr<gate> gate, bool clear_current_selection = true);
+    void select(std::shared_ptr<net> net, bool clear_current_selection = true);
+    void select(std::shared_ptr<module> module, bool clear_current_selection = true);
+    void select(std::vector<std::shared_ptr<gate>> gates, bool clear_current_selection = true);
+    void select(std::vector<std::shared_ptr<net>> nets, bool clear_current_selection = true);
+    void select(std::vector<std::shared_ptr<module>> modules, bool clear_current_selection = true);
+    void select(std::vector<u32> gate_ids, std::vector<u32> net_ids, std::vector<u32> module_ids, bool clear_current_selection = true);
+    void select(std::vector<std::shared_ptr<gate>> gates, std::vector<std::shared_ptr<net>> nets, std::vector<std::shared_ptr<module>> modules, bool clear_current_selection = true);
+
+    void clear_gate(u32 gate_id);
+    void clear_gate(std::vector<u32> gate_ids);
+    void clear_gate(std::shared_ptr<gate> gate);
+    void clear_gate(std::vector<std::shared_ptr<gate>> gates);
+
+    void clear_net(u32 net_id);
+    void clear_net(std::vector<u32> net_ids);
+    void clear_net(std::shared_ptr<net> net);
+    void clear_net(std::vector<std::shared_ptr<net>> nets);
+
+    void clear_module(u32 module_id);  
+    void clear_module(std::vector<u32> module_ids );
+    void clear_module(std::shared_ptr<module> modul);
+    void clear_module(std::vector<std::shared_ptr<module>> modules);
+
+    void clear();
+    void clear(std::shared_ptr<gate> gate);
+    void clear(std::shared_ptr<net> net);
+    void clear(std::shared_ptr<module> module);
+    void clear(std::vector<std::shared_ptr<gate>> gates);
+    void clear(std::vector<std::shared_ptr<net>> nets);
+    void clear(std::vector<std::shared_ptr<module>> modules);
+    void clear(std::vector<u32> gate_ids, std::vector<u32> net_ids, std::vector<u32> module_ids );
+    void clear(std::vector<std::shared_ptr<gate>> gates, std::vector<std::shared_ptr<net>> nets, std::vector<std::shared_ptr<module>> modules);
+};
+
+#endif // GUI_API_H

--- a/include/gui/gui_api/gui_api.h
+++ b/include/gui/gui_api/gui_api.h
@@ -14,69 +14,71 @@ public:
     gui_api();
     ~gui_api();
 
-    std::vector<u32> get_selected_gate_ids();
-    std::vector<u32> get_selected_net_ids();
-    std::vector<u32> get_selected_module_ids();
-    std::tuple<std::vector<u32>, std::vector<u32>, std::vector<u32>> get_selected_item_ids();
+    std::vector<u32> get_selected_gate_ids() const;
+    std::vector<u32> get_selected_net_ids() const;
+    std::vector<u32> get_selected_module_ids() const;
+    std::tuple<std::vector<u32>, std::vector<u32>, std::vector<u32>> get_selected_item_ids() const;
 
-    std::vector<std::shared_ptr<gate>> get_selected_gates();
-    std::vector<std::shared_ptr<net>> get_selected_nets();
-    std::vector<std::shared_ptr<module>> get_selected_modules();
-    std::tuple<std::vector<std::shared_ptr<gate>>, std::vector<std::shared_ptr<net>>, std::vector<std::shared_ptr<module>>> get_selected_items();
+    std::vector<std::shared_ptr<gate>> get_selected_gates() const;
+    std::vector<std::shared_ptr<net>> get_selected_nets() const;
+    std::vector<std::shared_ptr<module>> get_selected_modules() const;
+    std::tuple<std::vector<std::shared_ptr<gate>>, std::vector<std::shared_ptr<net>>, std::vector<std::shared_ptr<module>>> get_selected_items() const;
 
-    void print_selected_gates();
-    void print_selected_nets();
-    void print_selected_modules();
-    void print_selected_items();
+    /*
+    void print_selected_gates() const;
+    void print_selected_nets() const;
+    void print_selected_modules() const;
+    void print_selected_items() const;
+    */
 
     void select_gate(u32 gate_id, bool clear_current_selection = true);
-    void select_gate(std::vector<u32> gate_ids, bool clear_current_selection = true);
-    void select_gate(std::shared_ptr<gate> gate, bool clear_current_selection = true);
-    void select_gate(std::vector<std::shared_ptr<gate>> gates, bool clear_current_selection = true);
+    void select_gate(const std::vector<u32>& gate_ids, bool clear_current_selection = true);
+    void select_gate(const std::shared_ptr<gate> gate, bool clear_current_selection = true);
+    void select_gate(const std::vector<std::shared_ptr<gate>>& gates, bool clear_current_selection = true);
 
     void select_net(u32 net_id, bool clear_current_selection = true);
-    void select_net(std::vector<u32> net_ids, bool clear_current_selection = true);
-    void select_net(std::shared_ptr<net> net, bool clear_current_selection = true);
-    void select_net(std::vector<std::shared_ptr<net>> nets, bool clear_current_selection = true);
+    void select_net(const std::vector<u32>& net_ids, bool clear_current_selection = true);
+    void select_net(const std::shared_ptr<net> net, bool clear_current_selection = true);
+    void select_net(const std::vector<std::shared_ptr<net>>& nets, bool clear_current_selection = true);
 
     void select_module(u32 module_id, bool clear_current_selection = true);  
-    void select_module(std::vector<u32> module_ids, bool clear_current_selection = true);
-    void select_module(std::shared_ptr<module> module, bool clear_current_selection = true);
-    void select_module(std::vector<std::shared_ptr<module>> modules, bool clear_current_selection = true);
+    void select_module(const std::vector<u32>& module_ids, bool clear_current_selection = true);
+    void select_module(const std::shared_ptr<module> module, bool clear_current_selection = true);
+    void select_module(const std::vector<std::shared_ptr<module>>& modules, bool clear_current_selection = true);
 
-    void select(std::shared_ptr<gate> gate, bool clear_current_selection = true);
-    void select(std::shared_ptr<net> net, bool clear_current_selection = true);
-    void select(std::shared_ptr<module> module, bool clear_current_selection = true);
-    void select(std::vector<std::shared_ptr<gate>> gates, bool clear_current_selection = true);
-    void select(std::vector<std::shared_ptr<net>> nets, bool clear_current_selection = true);
-    void select(std::vector<std::shared_ptr<module>> modules, bool clear_current_selection = true);
-    void select(std::vector<u32> gate_ids, std::vector<u32> net_ids, std::vector<u32> module_ids, bool clear_current_selection = true);
-    void select(std::vector<std::shared_ptr<gate>> gates, std::vector<std::shared_ptr<net>> nets, std::vector<std::shared_ptr<module>> modules, bool clear_current_selection = true);
+    void select(const std::shared_ptr<gate> gate, bool clear_current_selection = true);
+    void select(const std::shared_ptr<net> net, bool clear_current_selection = true);
+    void select(const std::shared_ptr<module> module, bool clear_current_selection = true);
+    void select(const std::vector<std::shared_ptr<gate>>& gates, bool clear_current_selection = true);
+    void select(const std::vector<std::shared_ptr<net>>& nets, bool clear_current_selection = true);
+    void select(const std::vector<std::shared_ptr<module>>& modules, bool clear_current_selection = true);
+    void select(const std::vector<u32>& gate_ids, const std::vector<u32>& net_ids, const std::vector<u32>& module_ids, bool clear_current_selection = true);
+    void select(const std::vector<std::shared_ptr<gate>>& gates, const std::vector<std::shared_ptr<net>>& nets, const std::vector<std::shared_ptr<module>>& modules, bool clear_current_selection = true);
 
-    void clear_gate(u32 gate_id);
-    void clear_gate(std::vector<u32> gate_ids);
-    void clear_gate(std::shared_ptr<gate> gate);
-    void clear_gate(std::vector<std::shared_ptr<gate>> gates);
+    void deselect_gate(u32 gate_id);
+    void deselect_gate(const std::vector<u32>& gate_ids);
+    void deselect_gate(const std::shared_ptr<gate> gate);
+    void deselect_gate(const std::vector<std::shared_ptr<gate>>& gates);
 
-    void clear_net(u32 net_id);
-    void clear_net(std::vector<u32> net_ids);
-    void clear_net(std::shared_ptr<net> net);
-    void clear_net(std::vector<std::shared_ptr<net>> nets);
+    void deselect_net(u32 net_id);
+    void deselect_net(const std::vector<u32>& net_ids);
+    void deselect_net(const std::shared_ptr<net> net);
+    void deselect_net(const std::vector<std::shared_ptr<net>>& nets);
 
-    void clear_module(u32 module_id);  
-    void clear_module(std::vector<u32> module_ids );
-    void clear_module(std::shared_ptr<module> modul);
-    void clear_module(std::vector<std::shared_ptr<module>> modules);
+    void deselect_module(u32 module_id);  
+    void deselect_module(const std::vector<u32>& module_ids );
+    void deselect_module(const std::shared_ptr<module> modul);
+    void deselect_module(const std::vector<std::shared_ptr<module>>& modules);
 
-    void clear();
-    void clear(std::shared_ptr<gate> gate);
-    void clear(std::shared_ptr<net> net);
-    void clear(std::shared_ptr<module> module);
-    void clear(std::vector<std::shared_ptr<gate>> gates);
-    void clear(std::vector<std::shared_ptr<net>> nets);
-    void clear(std::vector<std::shared_ptr<module>> modules);
-    void clear(std::vector<u32> gate_ids, std::vector<u32> net_ids, std::vector<u32> module_ids );
-    void clear(std::vector<std::shared_ptr<gate>> gates, std::vector<std::shared_ptr<net>> nets, std::vector<std::shared_ptr<module>> modules);
+    void deselect_all_items();
+    void deselect(const std::shared_ptr<gate> gate);
+    void deselect(const std::shared_ptr<net> net);
+    void deselect(const std::shared_ptr<module> module);
+    void deselect(const std::vector<std::shared_ptr<gate>>& gates);
+    void deselect(const std::vector<std::shared_ptr<net>>& nets);
+    void deselect(const std::vector<std::shared_ptr<module>>& modules);
+    void deselect(const std::vector<u32>& gate_ids, const std::vector<u32>& net_ids, const std::vector<u32>& module_ids );
+    void deselect(const std::vector<std::shared_ptr<gate>>& gates, const std::vector<std::shared_ptr<net>>& nets, const std::vector<std::shared_ptr<module>>& modules);
 };
 
 #endif // GUI_API_H

--- a/include/gui/gui_api/gui_api.h
+++ b/include/gui/gui_api/gui_api.h
@@ -33,22 +33,22 @@ public:
 
     void select_gate(u32 gate_id, bool clear_current_selection = true);
     void select_gate(const std::vector<u32>& gate_ids, bool clear_current_selection = true);
-    void select_gate(const std::shared_ptr<gate> gate, bool clear_current_selection = true);
+    void select_gate(const std::shared_ptr<gate>& gate, bool clear_current_selection = true);
     void select_gate(const std::vector<std::shared_ptr<gate>>& gates, bool clear_current_selection = true);
 
     void select_net(u32 net_id, bool clear_current_selection = true);
     void select_net(const std::vector<u32>& net_ids, bool clear_current_selection = true);
-    void select_net(const std::shared_ptr<net> net, bool clear_current_selection = true);
+    void select_net(const std::shared_ptr<net>& net, bool clear_current_selection = true);
     void select_net(const std::vector<std::shared_ptr<net>>& nets, bool clear_current_selection = true);
 
     void select_module(u32 module_id, bool clear_current_selection = true);  
     void select_module(const std::vector<u32>& module_ids, bool clear_current_selection = true);
-    void select_module(const std::shared_ptr<module> module, bool clear_current_selection = true);
+    void select_module(const std::shared_ptr<module>& module, bool clear_current_selection = true);
     void select_module(const std::vector<std::shared_ptr<module>>& modules, bool clear_current_selection = true);
 
-    void select(const std::shared_ptr<gate> gate, bool clear_current_selection = true);
-    void select(const std::shared_ptr<net> net, bool clear_current_selection = true);
-    void select(const std::shared_ptr<module> module, bool clear_current_selection = true);
+    void select(const std::shared_ptr<gate>& gate, bool clear_current_selection = true);
+    void select(const std::shared_ptr<net>& net, bool clear_current_selection = true);
+    void select(const std::shared_ptr<module>& module, bool clear_current_selection = true);
     void select(const std::vector<std::shared_ptr<gate>>& gates, bool clear_current_selection = true);
     void select(const std::vector<std::shared_ptr<net>>& nets, bool clear_current_selection = true);
     void select(const std::vector<std::shared_ptr<module>>& modules, bool clear_current_selection = true);
@@ -57,23 +57,23 @@ public:
 
     void deselect_gate(u32 gate_id);
     void deselect_gate(const std::vector<u32>& gate_ids);
-    void deselect_gate(const std::shared_ptr<gate> gate);
+    void deselect_gate(const std::shared_ptr<gate>& gate);
     void deselect_gate(const std::vector<std::shared_ptr<gate>>& gates);
 
     void deselect_net(u32 net_id);
     void deselect_net(const std::vector<u32>& net_ids);
-    void deselect_net(const std::shared_ptr<net> net);
+    void deselect_net(const std::shared_ptr<net>& net);
     void deselect_net(const std::vector<std::shared_ptr<net>>& nets);
 
     void deselect_module(u32 module_id);  
-    void deselect_module(const std::vector<u32>& module_ids );
-    void deselect_module(const std::shared_ptr<module> modul);
+    void deselect_module(const std::vector<u32>& module_ids);
+    void deselect_module(const std::shared_ptr<module>& module);
     void deselect_module(const std::vector<std::shared_ptr<module>>& modules);
 
     void deselect_all_items();
-    void deselect(const std::shared_ptr<gate> gate);
-    void deselect(const std::shared_ptr<net> net);
-    void deselect(const std::shared_ptr<module> module);
+    void deselect(const std::shared_ptr<gate>& gate);
+    void deselect(const std::shared_ptr<net>& net);
+    void deselect(const std::shared_ptr<module>& module);
     void deselect(const std::vector<std::shared_ptr<gate>>& gates);
     void deselect(const std::vector<std::shared_ptr<net>>& nets);
     void deselect(const std::vector<std::shared_ptr<module>>& modules);

--- a/include/gui/gui_globals.h
+++ b/include/gui/gui_globals.h
@@ -39,6 +39,7 @@
 #include "gui/settings/settings_manager.h"
 #include "gui/thread_pool/thread_pool.h"
 #include "gui/window_manager/window_manager.h"
+#include "gui/gui_api/gui_api.h"
 
 #include <QSettings>
 
@@ -68,6 +69,8 @@ extern graph_context_manager g_graph_context_manager;
 extern thread_pool* g_thread_pool;
 
 extern std::unique_ptr<python_context> g_python_context;
+
+extern gui_api g_gui_api;
 
 // Comment this out to not compile the debug code for the graph grid.
 // This will also hide the respective debug setting from the settings page.

--- a/src/gui/gui_api/gui_api.cpp
+++ b/src/gui/gui_api/gui_api.cpp
@@ -1,0 +1,466 @@
+#include "gui_api/gui_api.h"
+
+#include "gui_globals.h"
+
+#include <algorithm>
+#include <QSet>
+
+gui_api::gui_api()
+{
+    g_selection_relay.register_sender(this, "GPU API");
+}
+
+gui_api::~gui_api()
+{
+    g_selection_relay.remove_sender(this);
+}
+
+std::vector<u32> gui_api::get_selected_gate_ids()
+{
+    return std::vector<u32>(g_selection_relay.m_selected_gates.begin(), g_selection_relay.m_selected_gates.end());
+}
+
+std::vector<u32> gui_api::get_selected_net_ids()
+{
+    return std::vector<u32>(g_selection_relay.m_selected_nets.begin(), g_selection_relay.m_selected_nets.end());
+}
+
+std::vector<u32> gui_api::get_selected_module_ids()
+{
+    return std::vector<u32>(g_selection_relay.m_selected_modules.begin(), g_selection_relay.m_selected_modules.end());
+}
+
+std::tuple<std::vector<u32>, std::vector<u32>, std::vector<u32>> gui_api::get_selected_item_ids()
+{
+    std::tuple<std::vector<u32>, std::vector<u32>, std::vector<u32>> selected_items_ids;
+    selected_items_ids = std::make_tuple(get_selected_gate_ids(), get_selected_net_ids(), get_selected_module_ids());
+
+    return selected_items_ids;
+}
+
+std::vector<std::shared_ptr<gate>> gui_api::get_selected_gates()
+{
+    std::vector<std::shared_ptr<gate>> gates(g_selection_relay.m_selected_gates.size());
+    std::transform(g_selection_relay.m_selected_gates.begin(), g_selection_relay.m_selected_gates.end(), gates.begin(), [](u32 id){return g_netlist->get_gate_by_id(id);});
+
+    return gates;
+}
+
+std::vector<std::shared_ptr<net>> gui_api::get_selected_nets()
+{   
+    std::vector<std::shared_ptr<net>> nets(g_selection_relay.m_selected_nets.size());
+    std::transform(g_selection_relay.m_selected_nets.begin(), g_selection_relay.m_selected_nets.end(), nets.begin(), [](u32 id){return g_netlist->get_net_by_id(id);});
+
+    return nets;
+}
+
+std::vector<std::shared_ptr<module>> gui_api::get_selected_modules()
+{
+    std::vector<std::shared_ptr<module>> modules(g_selection_relay.m_selected_modules.size());
+    std::transform(g_selection_relay.m_selected_modules.begin(), g_selection_relay.m_selected_modules.end(), modules.begin(), [](u32 id){return g_netlist->get_module_by_id(id);});
+
+    return modules;
+}
+
+std::tuple<std::vector<std::shared_ptr<gate>>, std::vector<std::shared_ptr<net>>, std::vector<std::shared_ptr<module>>> gui_api::get_selected_items()
+{
+    std::tuple<std::vector<std::shared_ptr<gate>>, std::vector<std::shared_ptr<net>>, std::vector<std::shared_ptr<module>>> selected_items;
+    selected_items = std::make_tuple(get_selected_gates(), get_selected_nets(), get_selected_modules());
+    
+    return selected_items;
+}
+
+void gui_api::print_selected_gates()
+{
+    u32 number_of_selected_gates = g_selection_relay.m_selected_gates.size();
+    QString header = QString("Selected gates (%1):").arg(number_of_selected_gates);
+    g_python_context->forward_stdout(header + "\n\n");
+    g_python_context->forward_stdout("ID\tName\n");
+
+    for(u32 gate_id : g_selection_relay.m_selected_gates)
+    {
+        auto gate = g_netlist->get_gate_by_id(gate_id);
+        QString id = QString::number(gate->get_id());
+        QString name = QString::fromStdString(gate->get_name());
+
+        g_python_context->forward_stdout(id + "\t" + name + "\n");
+    }
+}
+
+void gui_api::print_selected_nets()
+{
+    u32 number_of_selected_nets = g_selection_relay.m_selected_nets.size();
+    QString header = QString("Selected nets (%1):").arg(number_of_selected_nets);
+    g_python_context->forward_stdout(header + "\n\n");
+    g_python_context->forward_stdout("ID\tName\n");
+
+    for(u32 net_id : g_selection_relay.m_selected_nets)
+    {
+        auto net = g_netlist->get_net_by_id(net_id);
+        QString id = QString::number(net->get_id());
+        QString name = QString::fromStdString(net->get_name());
+
+        g_python_context->forward_stdout(id + "\t" + name + "\n");
+    }
+}
+
+void gui_api::print_selected_modules()
+{
+    u32 number_of_selected_modules = g_selection_relay.m_selected_modules.size();
+    QString header = QString("Selected modules (%1):").arg(number_of_selected_modules);
+    g_python_context->forward_stdout(header + "\n\n");
+    g_python_context->forward_stdout("ID\tName\n");
+
+    for(u32 module_id : g_selection_relay.m_selected_modules)
+    {
+        auto module = g_netlist->get_module_by_id(module_id);
+        QString id = QString::number(module->get_id());
+        QString name = QString::fromStdString(module->get_name());
+
+        g_python_context->forward_stdout(id + "\t" + name + "\n");
+    }
+}
+
+void gui_api::print_selected_items()
+{
+    print_selected_gates();
+    g_python_context->forward_stdout("\n");
+    print_selected_nets();
+    g_python_context->forward_stdout("\n");
+    print_selected_modules();
+}
+
+void gui_api::select_gate(std::shared_ptr<gate> gate, bool clear_current_selection)
+{
+    if(!g_netlist->is_gate_in_netlist(gate))
+        return;
+
+    if(clear_current_selection)
+        g_selection_relay.clear();
+
+    g_selection_relay.m_selected_gates.insert(gate->get_id());
+    g_selection_relay.selection_changed(this);
+}
+
+void gui_api::select_gate(u32 gate_id, bool clear_current_selection)
+{
+    select_gate(g_netlist->get_gate_by_id(gate_id), clear_current_selection);
+}
+
+void gui_api::select_gate(std::vector<std::shared_ptr<gate>> gates, bool clear_current_selection)
+{
+    QSet<u32> gate_ids;
+
+    for(auto gate : gates)
+    {
+        if(!g_netlist->is_gate_in_netlist(gate))
+            return;
+
+        gate_ids.insert(gate->get_id());    
+    }
+
+    if(clear_current_selection)
+        g_selection_relay.clear();
+
+    g_selection_relay.m_selected_gates.unite(gate_ids);
+    g_selection_relay.selection_changed(this);
+}
+
+void gui_api::select_gate(std::vector<u32> gate_ids, bool clear_current_selection)
+{
+    std::vector<std::shared_ptr<gate>> gates(gate_ids.size());
+    std::transform(gate_ids.begin(), gate_ids.end(), gates.begin(), [](u32 gate_id){return g_netlist->get_gate_by_id(gate_id);});
+    select_gate(gates, clear_current_selection);
+}
+
+void gui_api::select_net(std::shared_ptr<net> net, bool clear_current_selection)
+{
+    if(!g_netlist->is_net_in_netlist(net))
+        return;
+
+    if(clear_current_selection)
+        g_selection_relay.clear();
+
+    g_selection_relay.m_selected_nets.insert(net->get_id());
+    g_selection_relay.selection_changed(this);
+}
+
+void gui_api::select_net(u32 net_id, bool clear_current_selection)
+{
+    select_net(g_netlist->get_net_by_id(net_id), clear_current_selection);
+}
+
+void gui_api::select_net(std::vector<std::shared_ptr<net>> nets, bool clear_current_selection)
+{
+    QSet<u32> net_ids;
+
+    for(auto net : nets)
+    {
+        if(!g_netlist->is_net_in_netlist(net))
+            return;
+
+        net_ids.insert(net->get_id());    
+    }
+
+    if(clear_current_selection)
+        g_selection_relay.clear();
+
+    g_selection_relay.m_selected_nets.unite(net_ids);
+    g_selection_relay.selection_changed(this);
+}
+
+void gui_api::select_net(std::vector<u32> net_ids, bool clear_current_selection)
+{
+    std::vector<std::shared_ptr<net>> nets(net_ids.size());
+    std::transform(net_ids.begin(), net_ids.end(), nets.begin(), [](u32 net_id){return g_netlist->get_net_by_id(net_id);});
+    select_net(nets, clear_current_selection);
+}
+
+void gui_api::select_module(std::shared_ptr<module> module, bool clear_current_selection)
+{
+    if(!g_netlist->is_module_in_netlist(module))
+        return;
+
+    if(clear_current_selection)
+        g_selection_relay.clear();
+
+    g_selection_relay.m_selected_modules.insert(module->get_id());
+    g_selection_relay.selection_changed(this);
+}
+
+void gui_api::select_module(u32 module_id, bool clear_current_selection)
+{
+    select_module(g_netlist->get_module_by_id(module_id), clear_current_selection);
+}
+
+void gui_api::select_module(std::vector<std::shared_ptr<module>> modules, bool clear_current_selection)
+{
+    QSet<u32> module_ids;
+
+    for(auto module : modules)
+    {
+        if(!g_netlist->is_module_in_netlist(module))
+            return;
+
+        module_ids.insert(module->get_id());    
+    }
+
+    if(clear_current_selection)
+        g_selection_relay.clear();
+
+    g_selection_relay.m_selected_modules.unite(module_ids);
+    g_selection_relay.selection_changed(this);
+}
+
+void gui_api::select_module(std::vector<u32> module_ids, bool clear_current_selection)
+{
+    std::vector<std::shared_ptr<module>> modules(module_ids.size());
+    std::transform(module_ids.begin(), module_ids.end(), modules.begin(), [](u32 g_id){return g_netlist->get_module_by_id(g_id);});
+    select_module(modules, clear_current_selection);
+}
+
+void gui_api::select(std::shared_ptr<gate> gate, bool clear_current_selection)
+{
+    select_gate(gate, clear_current_selection);
+}
+
+void gui_api::select(std::shared_ptr<net> net, bool clear_current_selection)
+{
+    select_net(net, clear_current_selection);
+}
+void gui_api::select(std::shared_ptr<module> module, bool clear_current_selection)
+{
+    select_module(module, clear_current_selection);
+}
+
+void gui_api::select(std::vector<std::shared_ptr<gate>> gates, bool clear_current_selection)
+{
+    select_gate(gates, clear_current_selection);
+}
+void gui_api::select(std::vector<std::shared_ptr<net>> nets, bool clear_current_selection)
+{
+    select_net(nets, clear_current_selection);
+}
+
+void gui_api::select(std::vector<std::shared_ptr<module>> modules, bool clear_current_selection)
+{
+    select_module(modules, clear_current_selection);
+}
+
+void gui_api::select(std::vector<u32> gate_ids, std::vector<u32> net_ids, std::vector<u32> module_ids, bool clear_current_selection)
+{
+    if(clear_current_selection)
+        g_selection_relay.clear();
+
+    select_gate(gate_ids, false);
+    select_net(net_ids, false);
+    select_module(module_ids, false);
+}
+
+void gui_api::select(std::vector<std::shared_ptr<gate>> gates, std::vector<std::shared_ptr<net>> nets, std::vector<std::shared_ptr<module>> modules, bool clear_current_selection)
+{
+    if(clear_current_selection)
+        g_selection_relay.clear();
+
+    select_gate(gates, false);
+    select_net(nets, false);
+    select_module(modules, false);
+}
+
+void gui_api::clear_gate(std::shared_ptr<gate> gate)
+{
+    if(!g_netlist->is_gate_in_netlist(gate))
+        return;
+
+    g_selection_relay.m_selected_gates.remove(gate->get_id());
+    g_selection_relay.selection_changed(this);
+}
+
+void gui_api::clear_gate(u32 gate_id)
+{
+    clear_gate(g_netlist->get_gate_by_id(gate_id));
+}
+
+void gui_api::clear_gate(std::vector<std::shared_ptr<gate>> gates)
+{
+    QSet<u32> gate_ids;
+
+    for(std::shared_ptr<gate> gate : gates)
+    {
+        if(!g_netlist->is_gate_in_netlist(gate))
+            return;
+
+        gate_ids.insert(gate->get_id());    
+    }
+
+    g_selection_relay.m_selected_gates.subtract(gate_ids);
+    g_selection_relay.selection_changed(this);
+}
+
+void gui_api::clear_gate(std::vector<u32> gate_ids)
+{
+    std::vector<std::shared_ptr<gate>> gates(gate_ids.size());
+    std::transform(gate_ids.begin(), gate_ids.end(), gates.begin(), [](u32 gate_id){return g_netlist->get_gate_by_id(gate_id);});
+    clear_gate(gates);
+}
+
+void gui_api::clear_net(std::shared_ptr<net> net)
+{
+    if(!g_netlist->is_net_in_netlist(net))
+        return;
+
+    g_selection_relay.m_selected_nets.remove(net->get_id());
+    g_selection_relay.selection_changed(this);
+}
+
+void gui_api::clear_net(u32 net_id)
+{
+    clear_net(g_netlist->get_net_by_id(net_id));
+}
+
+void gui_api::clear_net(std::vector<std::shared_ptr<net>> nets)
+{
+    QSet<u32> net_ids;
+
+    for(std::shared_ptr<net> net : nets)
+    {
+        if(!g_netlist->is_net_in_netlist(net))
+            return;
+
+        net_ids.insert(net->get_id());    
+    }
+
+    g_selection_relay.m_selected_nets.subtract(net_ids);
+    g_selection_relay.selection_changed(this);
+}
+
+void gui_api::clear_net(std::vector<u32> net_ids)
+{
+    std::vector<std::shared_ptr<net>> nets(net_ids.size());
+    std::transform(net_ids.begin(), net_ids.end(), nets.begin(), [](u32 net_id){return g_netlist->get_net_by_id(net_id);});
+    clear_net(nets);
+}
+
+void gui_api::clear_module(std::shared_ptr<module> module)
+{
+    if(!g_netlist->is_module_in_netlist(module))
+        return;
+
+    g_selection_relay.m_selected_modules.remove(module->get_id());
+    g_selection_relay.selection_changed(this);
+}
+
+void gui_api::clear_module(u32 module_id)
+{
+    clear_module(g_netlist->get_module_by_id(module_id));
+}
+
+void gui_api::clear_module(std::vector<std::shared_ptr<module>> modules)
+{
+    QSet<u32> module_ids;
+
+    for(std::shared_ptr<module> module : modules)
+    {
+        if(!g_netlist->is_module_in_netlist(module))
+            return;
+
+        module_ids.insert(module->get_id());    
+    }
+
+    g_selection_relay.m_selected_modules.subtract(module_ids);
+    g_selection_relay.selection_changed(this);
+}
+
+void gui_api::clear_module(std::vector<u32> module_ids)
+{
+    std::vector<std::shared_ptr<module>> modules(module_ids.size());
+    std::transform(module_ids.begin(), module_ids.end(), modules.begin(), [](u32 module_id){return g_netlist->get_module_by_id(module_id);});
+    clear_module(modules);
+}
+
+void gui_api::clear(std::shared_ptr<gate> gate)
+{
+    clear_gate(gate);
+}
+
+void gui_api::clear(std::shared_ptr<net> net)
+{
+    clear_net(net);
+}
+void gui_api::clear(std::shared_ptr<module> module)
+{
+    clear_module(module);
+}
+
+void gui_api::clear(std::vector<std::shared_ptr<gate>> gates)
+{
+    clear_gate(gates);
+}
+void gui_api::clear(std::vector<std::shared_ptr<net>> nets)
+{
+    clear_net(nets);
+}
+
+void gui_api::clear(std::vector<std::shared_ptr<module>> modules)
+{
+    clear_module(modules);
+}
+
+void gui_api::clear(std::vector<u32> gate_ids, std::vector<u32> net_ids, std::vector<u32> module_ids)
+{
+    clear_gate(gate_ids);
+    clear_net(net_ids);
+    clear_module(module_ids);
+}
+
+void gui_api::clear(std::vector<std::shared_ptr<gate>> gates, std::vector<std::shared_ptr<net>> nets, std::vector<std::shared_ptr<module>> modules)
+{
+    clear_gate(gates);
+    clear_net(nets);
+    clear_module(modules);
+}
+
+void gui_api::clear()
+{
+    g_selection_relay.clear_and_update();
+}

--- a/src/gui/gui_api/gui_api.cpp
+++ b/src/gui/gui_api/gui_api.cpp
@@ -7,7 +7,7 @@
 
 gui_api::gui_api()
 {
-    g_selection_relay.register_sender(this, "GPU API");
+    g_selection_relay.register_sender(this, "GUI API");
 }
 
 gui_api::~gui_api()
@@ -15,30 +15,27 @@ gui_api::~gui_api()
     g_selection_relay.remove_sender(this);
 }
 
-std::vector<u32> gui_api::get_selected_gate_ids()
+std::vector<u32> gui_api::get_selected_gate_ids() const
 {
     return std::vector<u32>(g_selection_relay.m_selected_gates.begin(), g_selection_relay.m_selected_gates.end());
 }
 
-std::vector<u32> gui_api::get_selected_net_ids()
+std::vector<u32> gui_api::get_selected_net_ids() const
 {
     return std::vector<u32>(g_selection_relay.m_selected_nets.begin(), g_selection_relay.m_selected_nets.end());
 }
 
-std::vector<u32> gui_api::get_selected_module_ids()
+std::vector<u32> gui_api::get_selected_module_ids() const
 {
     return std::vector<u32>(g_selection_relay.m_selected_modules.begin(), g_selection_relay.m_selected_modules.end());
 }
 
-std::tuple<std::vector<u32>, std::vector<u32>, std::vector<u32>> gui_api::get_selected_item_ids()
+std::tuple<std::vector<u32>, std::vector<u32>, std::vector<u32>> gui_api::get_selected_item_ids() const
 {
-    std::tuple<std::vector<u32>, std::vector<u32>, std::vector<u32>> selected_items_ids;
-    selected_items_ids = std::make_tuple(get_selected_gate_ids(), get_selected_net_ids(), get_selected_module_ids());
-
-    return selected_items_ids;
+    return std::make_tuple(get_selected_gate_ids(), get_selected_net_ids(), get_selected_module_ids());
 }
 
-std::vector<std::shared_ptr<gate>> gui_api::get_selected_gates()
+std::vector<std::shared_ptr<gate>> gui_api::get_selected_gates() const
 {
     std::vector<std::shared_ptr<gate>> gates(g_selection_relay.m_selected_gates.size());
     std::transform(g_selection_relay.m_selected_gates.begin(), g_selection_relay.m_selected_gates.end(), gates.begin(), [](u32 id){return g_netlist->get_gate_by_id(id);});
@@ -46,7 +43,7 @@ std::vector<std::shared_ptr<gate>> gui_api::get_selected_gates()
     return gates;
 }
 
-std::vector<std::shared_ptr<net>> gui_api::get_selected_nets()
+std::vector<std::shared_ptr<net>> gui_api::get_selected_nets() const
 {   
     std::vector<std::shared_ptr<net>> nets(g_selection_relay.m_selected_nets.size());
     std::transform(g_selection_relay.m_selected_nets.begin(), g_selection_relay.m_selected_nets.end(), nets.begin(), [](u32 id){return g_netlist->get_net_by_id(id);});
@@ -54,7 +51,7 @@ std::vector<std::shared_ptr<net>> gui_api::get_selected_nets()
     return nets;
 }
 
-std::vector<std::shared_ptr<module>> gui_api::get_selected_modules()
+std::vector<std::shared_ptr<module>> gui_api::get_selected_modules() const
 {
     std::vector<std::shared_ptr<module>> modules(g_selection_relay.m_selected_modules.size());
     std::transform(g_selection_relay.m_selected_modules.begin(), g_selection_relay.m_selected_modules.end(), modules.begin(), [](u32 id){return g_netlist->get_module_by_id(id);});
@@ -62,15 +59,13 @@ std::vector<std::shared_ptr<module>> gui_api::get_selected_modules()
     return modules;
 }
 
-std::tuple<std::vector<std::shared_ptr<gate>>, std::vector<std::shared_ptr<net>>, std::vector<std::shared_ptr<module>>> gui_api::get_selected_items()
+std::tuple<std::vector<std::shared_ptr<gate>>, std::vector<std::shared_ptr<net>>, std::vector<std::shared_ptr<module>>> gui_api::get_selected_items() const
 {
-    std::tuple<std::vector<std::shared_ptr<gate>>, std::vector<std::shared_ptr<net>>, std::vector<std::shared_ptr<module>>> selected_items;
-    selected_items = std::make_tuple(get_selected_gates(), get_selected_nets(), get_selected_modules());
-    
-    return selected_items;
+    return std::make_tuple(get_selected_gates(), get_selected_nets(), get_selected_modules());
 }
 
-void gui_api::print_selected_gates()
+/*
+void gui_api::print_selected_gates() const
 {
     u32 number_of_selected_gates = g_selection_relay.m_selected_gates.size();
     QString header = QString("Selected gates (%1):").arg(number_of_selected_gates);
@@ -87,7 +82,7 @@ void gui_api::print_selected_gates()
     }
 }
 
-void gui_api::print_selected_nets()
+void gui_api::print_selected_nets() const
 {
     u32 number_of_selected_nets = g_selection_relay.m_selected_nets.size();
     QString header = QString("Selected nets (%1):").arg(number_of_selected_nets);
@@ -104,7 +99,7 @@ void gui_api::print_selected_nets()
     }
 }
 
-void gui_api::print_selected_modules()
+void gui_api::print_selected_modules() const
 {
     u32 number_of_selected_modules = g_selection_relay.m_selected_modules.size();
     QString header = QString("Selected modules (%1):").arg(number_of_selected_modules);
@@ -121,7 +116,7 @@ void gui_api::print_selected_modules()
     }
 }
 
-void gui_api::print_selected_items()
+void gui_api::print_selected_items() const
 {
     print_selected_gates();
     g_python_context->forward_stdout("\n");
@@ -129,8 +124,9 @@ void gui_api::print_selected_items()
     g_python_context->forward_stdout("\n");
     print_selected_modules();
 }
+*/
 
-void gui_api::select_gate(std::shared_ptr<gate> gate, bool clear_current_selection)
+void gui_api::select_gate(const std::shared_ptr<gate> gate, bool clear_current_selection)
 {
     if(!g_netlist->is_gate_in_netlist(gate))
         return;
@@ -147,7 +143,7 @@ void gui_api::select_gate(u32 gate_id, bool clear_current_selection)
     select_gate(g_netlist->get_gate_by_id(gate_id), clear_current_selection);
 }
 
-void gui_api::select_gate(std::vector<std::shared_ptr<gate>> gates, bool clear_current_selection)
+void gui_api::select_gate(const std::vector<std::shared_ptr<gate>>& gates, bool clear_current_selection)
 {
     QSet<u32> gate_ids;
 
@@ -166,14 +162,14 @@ void gui_api::select_gate(std::vector<std::shared_ptr<gate>> gates, bool clear_c
     g_selection_relay.selection_changed(this);
 }
 
-void gui_api::select_gate(std::vector<u32> gate_ids, bool clear_current_selection)
+void gui_api::select_gate(const std::vector<u32>& gate_ids, bool clear_current_selection)
 {
     std::vector<std::shared_ptr<gate>> gates(gate_ids.size());
     std::transform(gate_ids.begin(), gate_ids.end(), gates.begin(), [](u32 gate_id){return g_netlist->get_gate_by_id(gate_id);});
     select_gate(gates, clear_current_selection);
 }
 
-void gui_api::select_net(std::shared_ptr<net> net, bool clear_current_selection)
+void gui_api::select_net(const std::shared_ptr<net> net, bool clear_current_selection)
 {
     if(!g_netlist->is_net_in_netlist(net))
         return;
@@ -190,7 +186,7 @@ void gui_api::select_net(u32 net_id, bool clear_current_selection)
     select_net(g_netlist->get_net_by_id(net_id), clear_current_selection);
 }
 
-void gui_api::select_net(std::vector<std::shared_ptr<net>> nets, bool clear_current_selection)
+void gui_api::select_net(const std::vector<std::shared_ptr<net>>& nets, bool clear_current_selection)
 {
     QSet<u32> net_ids;
 
@@ -209,14 +205,14 @@ void gui_api::select_net(std::vector<std::shared_ptr<net>> nets, bool clear_curr
     g_selection_relay.selection_changed(this);
 }
 
-void gui_api::select_net(std::vector<u32> net_ids, bool clear_current_selection)
+void gui_api::select_net(const std::vector<u32>& net_ids, bool clear_current_selection)
 {
     std::vector<std::shared_ptr<net>> nets(net_ids.size());
     std::transform(net_ids.begin(), net_ids.end(), nets.begin(), [](u32 net_id){return g_netlist->get_net_by_id(net_id);});
     select_net(nets, clear_current_selection);
 }
 
-void gui_api::select_module(std::shared_ptr<module> module, bool clear_current_selection)
+void gui_api::select_module(const std::shared_ptr<module> module, bool clear_current_selection)
 {
     if(!g_netlist->is_module_in_netlist(module))
         return;
@@ -233,7 +229,7 @@ void gui_api::select_module(u32 module_id, bool clear_current_selection)
     select_module(g_netlist->get_module_by_id(module_id), clear_current_selection);
 }
 
-void gui_api::select_module(std::vector<std::shared_ptr<module>> modules, bool clear_current_selection)
+void gui_api::select_module(const std::vector<std::shared_ptr<module>>& modules, bool clear_current_selection)
 {
     QSet<u32> module_ids;
 
@@ -252,7 +248,7 @@ void gui_api::select_module(std::vector<std::shared_ptr<module>> modules, bool c
     g_selection_relay.selection_changed(this);
 }
 
-void gui_api::select_module(std::vector<u32> module_ids, bool clear_current_selection)
+void gui_api::select_module(const std::vector<u32>& module_ids, bool clear_current_selection)
 {
     std::vector<std::shared_ptr<module>> modules(module_ids.size());
     std::transform(module_ids.begin(), module_ids.end(), modules.begin(), [](u32 g_id){return g_netlist->get_module_by_id(g_id);});
@@ -273,21 +269,21 @@ void gui_api::select(std::shared_ptr<module> module, bool clear_current_selectio
     select_module(module, clear_current_selection);
 }
 
-void gui_api::select(std::vector<std::shared_ptr<gate>> gates, bool clear_current_selection)
+void gui_api::select(const std::vector<std::shared_ptr<gate>>& gates, bool clear_current_selection)
 {
     select_gate(gates, clear_current_selection);
 }
-void gui_api::select(std::vector<std::shared_ptr<net>> nets, bool clear_current_selection)
+void gui_api::select(const std::vector<std::shared_ptr<net>>& nets, bool clear_current_selection)
 {
     select_net(nets, clear_current_selection);
 }
 
-void gui_api::select(std::vector<std::shared_ptr<module>> modules, bool clear_current_selection)
+void gui_api::select(const std::vector<std::shared_ptr<module>>& modules, bool clear_current_selection)
 {
     select_module(modules, clear_current_selection);
 }
 
-void gui_api::select(std::vector<u32> gate_ids, std::vector<u32> net_ids, std::vector<u32> module_ids, bool clear_current_selection)
+void gui_api::select(const std::vector<u32>& gate_ids, const std::vector<u32>& net_ids, const std::vector<u32>& module_ids, bool clear_current_selection)
 {
     if(clear_current_selection)
         g_selection_relay.clear();
@@ -297,7 +293,7 @@ void gui_api::select(std::vector<u32> gate_ids, std::vector<u32> net_ids, std::v
     select_module(module_ids, false);
 }
 
-void gui_api::select(std::vector<std::shared_ptr<gate>> gates, std::vector<std::shared_ptr<net>> nets, std::vector<std::shared_ptr<module>> modules, bool clear_current_selection)
+void gui_api::select(const std::vector<std::shared_ptr<gate>>& gates, const std::vector<std::shared_ptr<net>>& nets, const std::vector<std::shared_ptr<module>>& modules, bool clear_current_selection)
 {
     if(clear_current_selection)
         g_selection_relay.clear();
@@ -307,7 +303,7 @@ void gui_api::select(std::vector<std::shared_ptr<gate>> gates, std::vector<std::
     select_module(modules, false);
 }
 
-void gui_api::clear_gate(std::shared_ptr<gate> gate)
+void gui_api::deselect_gate(const std::shared_ptr<gate> gate)
 {
     if(!g_netlist->is_gate_in_netlist(gate))
         return;
@@ -316,12 +312,12 @@ void gui_api::clear_gate(std::shared_ptr<gate> gate)
     g_selection_relay.selection_changed(this);
 }
 
-void gui_api::clear_gate(u32 gate_id)
+void gui_api::deselect_gate(u32 gate_id)
 {
-    clear_gate(g_netlist->get_gate_by_id(gate_id));
+    deselect_gate(g_netlist->get_gate_by_id(gate_id));
 }
 
-void gui_api::clear_gate(std::vector<std::shared_ptr<gate>> gates)
+void gui_api::deselect_gate(const std::vector<std::shared_ptr<gate>>& gates)
 {
     QSet<u32> gate_ids;
 
@@ -337,14 +333,14 @@ void gui_api::clear_gate(std::vector<std::shared_ptr<gate>> gates)
     g_selection_relay.selection_changed(this);
 }
 
-void gui_api::clear_gate(std::vector<u32> gate_ids)
+void gui_api::deselect_gate(const std::vector<u32>& gate_ids)
 {
     std::vector<std::shared_ptr<gate>> gates(gate_ids.size());
     std::transform(gate_ids.begin(), gate_ids.end(), gates.begin(), [](u32 gate_id){return g_netlist->get_gate_by_id(gate_id);});
-    clear_gate(gates);
+    deselect_gate(gates);
 }
 
-void gui_api::clear_net(std::shared_ptr<net> net)
+void gui_api::deselect_net(const std::shared_ptr<net> net)
 {
     if(!g_netlist->is_net_in_netlist(net))
         return;
@@ -353,12 +349,12 @@ void gui_api::clear_net(std::shared_ptr<net> net)
     g_selection_relay.selection_changed(this);
 }
 
-void gui_api::clear_net(u32 net_id)
+void gui_api::deselect_net(u32 net_id)
 {
-    clear_net(g_netlist->get_net_by_id(net_id));
+    deselect_net(g_netlist->get_net_by_id(net_id));
 }
 
-void gui_api::clear_net(std::vector<std::shared_ptr<net>> nets)
+void gui_api::deselect_net(const std::vector<std::shared_ptr<net>>& nets)
 {
     QSet<u32> net_ids;
 
@@ -374,14 +370,14 @@ void gui_api::clear_net(std::vector<std::shared_ptr<net>> nets)
     g_selection_relay.selection_changed(this);
 }
 
-void gui_api::clear_net(std::vector<u32> net_ids)
+void gui_api::deselect_net(const std::vector<u32>& net_ids)
 {
     std::vector<std::shared_ptr<net>> nets(net_ids.size());
     std::transform(net_ids.begin(), net_ids.end(), nets.begin(), [](u32 net_id){return g_netlist->get_net_by_id(net_id);});
-    clear_net(nets);
+    deselect_net(nets);
 }
 
-void gui_api::clear_module(std::shared_ptr<module> module)
+void gui_api::deselect_module(const std::shared_ptr<module> module)
 {
     if(!g_netlist->is_module_in_netlist(module))
         return;
@@ -390,12 +386,12 @@ void gui_api::clear_module(std::shared_ptr<module> module)
     g_selection_relay.selection_changed(this);
 }
 
-void gui_api::clear_module(u32 module_id)
+void gui_api::deselect_module(u32 module_id)
 {
-    clear_module(g_netlist->get_module_by_id(module_id));
+    deselect_module(g_netlist->get_module_by_id(module_id));
 }
 
-void gui_api::clear_module(std::vector<std::shared_ptr<module>> modules)
+void gui_api::deselect_module(const std::vector<std::shared_ptr<module>>& modules)
 {
     QSet<u32> module_ids;
 
@@ -411,56 +407,56 @@ void gui_api::clear_module(std::vector<std::shared_ptr<module>> modules)
     g_selection_relay.selection_changed(this);
 }
 
-void gui_api::clear_module(std::vector<u32> module_ids)
+void gui_api::deselect_module(const std::vector<u32>& module_ids)
 {
     std::vector<std::shared_ptr<module>> modules(module_ids.size());
     std::transform(module_ids.begin(), module_ids.end(), modules.begin(), [](u32 module_id){return g_netlist->get_module_by_id(module_id);});
-    clear_module(modules);
+    deselect_module(modules);
 }
 
-void gui_api::clear(std::shared_ptr<gate> gate)
+void gui_api::deselect(const std::shared_ptr<gate> gate)
 {
-    clear_gate(gate);
+    deselect_gate(gate);
 }
 
-void gui_api::clear(std::shared_ptr<net> net)
+void gui_api::deselect(const std::shared_ptr<net> net)
 {
-    clear_net(net);
+    deselect_net(net);
 }
-void gui_api::clear(std::shared_ptr<module> module)
+void gui_api::deselect(std::shared_ptr<module> module)
 {
-    clear_module(module);
-}
-
-void gui_api::clear(std::vector<std::shared_ptr<gate>> gates)
-{
-    clear_gate(gates);
-}
-void gui_api::clear(std::vector<std::shared_ptr<net>> nets)
-{
-    clear_net(nets);
+    deselect_module(module);
 }
 
-void gui_api::clear(std::vector<std::shared_ptr<module>> modules)
+void gui_api::deselect(const std::vector<std::shared_ptr<gate>>& gates)
 {
-    clear_module(modules);
+    deselect_gate(gates);
+}
+void gui_api::deselect(const std::vector<std::shared_ptr<net>>& nets)
+{
+    deselect_net(nets);
 }
 
-void gui_api::clear(std::vector<u32> gate_ids, std::vector<u32> net_ids, std::vector<u32> module_ids)
+void gui_api::deselect(const std::vector<std::shared_ptr<module>>& modules)
 {
-    clear_gate(gate_ids);
-    clear_net(net_ids);
-    clear_module(module_ids);
+    deselect_module(modules);
 }
 
-void gui_api::clear(std::vector<std::shared_ptr<gate>> gates, std::vector<std::shared_ptr<net>> nets, std::vector<std::shared_ptr<module>> modules)
+void gui_api::deselect(const std::vector<u32>& gate_ids, const std::vector<u32>& net_ids, const std::vector<u32>& module_ids)
 {
-    clear_gate(gates);
-    clear_net(nets);
-    clear_module(modules);
+    deselect_gate(gate_ids);
+    deselect_net(net_ids);
+    deselect_module(module_ids);
 }
 
-void gui_api::clear()
+void gui_api::deselect(const std::vector<std::shared_ptr<gate>>& gates, const std::vector<std::shared_ptr<net>>& nets, const std::vector<std::shared_ptr<module>>& modules)
+{
+    deselect_gate(gates);
+    deselect_net(nets);
+    deselect_module(modules);
+}
+
+void gui_api::deselect_all_items()
 {
     g_selection_relay.clear_and_update();
 }

--- a/src/gui/gui_api/gui_api.cpp
+++ b/src/gui/gui_api/gui_api.cpp
@@ -126,7 +126,7 @@ void gui_api::print_selected_items() const
 }
 */
 
-void gui_api::select_gate(const std::shared_ptr<gate> gate, bool clear_current_selection)
+void gui_api::select_gate(const std::shared_ptr<gate>& gate, bool clear_current_selection)
 {
     if(!g_netlist->is_gate_in_netlist(gate))
         return;
@@ -169,7 +169,7 @@ void gui_api::select_gate(const std::vector<u32>& gate_ids, bool clear_current_s
     select_gate(gates, clear_current_selection);
 }
 
-void gui_api::select_net(const std::shared_ptr<net> net, bool clear_current_selection)
+void gui_api::select_net(const std::shared_ptr<net>& net, bool clear_current_selection)
 {
     if(!g_netlist->is_net_in_netlist(net))
         return;
@@ -212,7 +212,7 @@ void gui_api::select_net(const std::vector<u32>& net_ids, bool clear_current_sel
     select_net(nets, clear_current_selection);
 }
 
-void gui_api::select_module(const std::shared_ptr<module> module, bool clear_current_selection)
+void gui_api::select_module(const std::shared_ptr<module>& module, bool clear_current_selection)
 {
     if(!g_netlist->is_module_in_netlist(module))
         return;
@@ -255,16 +255,16 @@ void gui_api::select_module(const std::vector<u32>& module_ids, bool clear_curre
     select_module(modules, clear_current_selection);
 }
 
-void gui_api::select(std::shared_ptr<gate> gate, bool clear_current_selection)
+void gui_api::select(const std::shared_ptr<gate>& gate, bool clear_current_selection)
 {
     select_gate(gate, clear_current_selection);
 }
 
-void gui_api::select(std::shared_ptr<net> net, bool clear_current_selection)
+void gui_api::select(const std::shared_ptr<net>& net, bool clear_current_selection)
 {
     select_net(net, clear_current_selection);
 }
-void gui_api::select(std::shared_ptr<module> module, bool clear_current_selection)
+void gui_api::select(const std::shared_ptr<module>& module, bool clear_current_selection)
 {
     select_module(module, clear_current_selection);
 }
@@ -303,7 +303,7 @@ void gui_api::select(const std::vector<std::shared_ptr<gate>>& gates, const std:
     select_module(modules, false);
 }
 
-void gui_api::deselect_gate(const std::shared_ptr<gate> gate)
+void gui_api::deselect_gate(const std::shared_ptr<gate>& gate)
 {
     if(!g_netlist->is_gate_in_netlist(gate))
         return;
@@ -340,7 +340,7 @@ void gui_api::deselect_gate(const std::vector<u32>& gate_ids)
     deselect_gate(gates);
 }
 
-void gui_api::deselect_net(const std::shared_ptr<net> net)
+void gui_api::deselect_net(const std::shared_ptr<net>& net)
 {
     if(!g_netlist->is_net_in_netlist(net))
         return;
@@ -377,7 +377,7 @@ void gui_api::deselect_net(const std::vector<u32>& net_ids)
     deselect_net(nets);
 }
 
-void gui_api::deselect_module(const std::shared_ptr<module> module)
+void gui_api::deselect_module(const std::shared_ptr<module>& module)
 {
     if(!g_netlist->is_module_in_netlist(module))
         return;
@@ -414,16 +414,16 @@ void gui_api::deselect_module(const std::vector<u32>& module_ids)
     deselect_module(modules);
 }
 
-void gui_api::deselect(const std::shared_ptr<gate> gate)
+void gui_api::deselect(const std::shared_ptr<gate>& gate)
 {
     deselect_gate(gate);
 }
 
-void gui_api::deselect(const std::shared_ptr<net> net)
+void gui_api::deselect(const std::shared_ptr<net>& net)
 {
     deselect_net(net);
 }
-void gui_api::deselect(std::shared_ptr<module> module)
+void gui_api::deselect(const std::shared_ptr<module>& module)
 {
     deselect_module(module);
 }

--- a/src/gui/plugin_gui.cpp
+++ b/src/gui/plugin_gui.cpp
@@ -22,6 +22,7 @@
 #include "gui/style/style.h"
 #include "gui/thread_pool/thread_pool.h"
 #include "gui/window_manager/window_manager.h"
+#include "gui/gui_api/gui_api.h"
 
 #include <signal.h>
 
@@ -63,6 +64,8 @@ thread_pool* g_thread_pool;
 graph_context_manager g_graph_context_manager;
 
 std::unique_ptr<python_context> g_python_context = nullptr;
+
+gui_api g_gui_api;
 
 // NOTE
 // ORDER = LOGGER -> SETTINGS -> (STYLE / RELAYS / OTHER STUFF) -> MAINWINDOW (= EVERYTHING ELSE & DATA)

--- a/src/gui/python/python_context.cpp
+++ b/src/gui/python/python_context.cpp
@@ -82,6 +82,7 @@ void python_context::initialize_context(py::dict* context)
              *context);
 
     (*context)["netlist"] = g_netlist;
+    (*context)["gui"] = g_gui_api;
 }
 
 void python_context::init_python()

--- a/src/python-binding/python_definitions.cpp
+++ b/src/python-binding/python_definitions.cpp
@@ -20,6 +20,7 @@
 #include "netlist/netlist.h"
 #include "netlist/netlist_factory.h"
 #include "netlist/persistent/netlist_serializer.h"
+#include "gui/gui_api/gui_api.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
@@ -2275,6 +2276,372 @@ py_boolean_function.def("get_truth_table", &boolean_function::get_truth_table, p
         :param list[str] ordered_variables: Specific order in which the inputs shall be structured in the truth table.
         :returns: The vector of output values.
         :rtype: list[value]
+)");
+
+py::class_<gui_api> py_gui_api(m, "gui", R"(Boolean function class.)");
+
+py_gui_api.def("get_selected_gate_ids", &gui_api::get_selected_gate_ids, R"(
+        Get the gate ids of currently selected gates in the graph view of the GUI.
+
+        :returns: List of the ids of the currently selected gates.
+        :rtype: list[int]
+)");
+
+py_gui_api.def("get_selected_net_ids", &gui_api::get_selected_net_ids, R"(
+        Get the net ids of currently selected nets in the graph view of the GUI.
+
+        :returns: List of the ids of the currently selected nets.
+        :rtype: list[int]
+)");
+
+py_gui_api.def("get_selected_module_ids", &gui_api::get_selected_module_ids, R"(
+        Get the module ids of currently selected modules in the graph view of the GUI.
+
+        :returns: List of the ids of the currently selected modules.
+        :rtype: list[int]
+)");
+
+py_gui_api.def("get_selected_item_ids", &gui_api::get_selected_item_ids, R"(
+        Get all item ids of the currently selected items in the graph view of the GUI.
+
+        :returns: Tuple of lists of the currently selected items.
+        :rtype: tuple(int, int, int)
+)");
+
+py_gui_api.def("get_selected_gates", &gui_api::get_selected_gates, R"(
+        Get the gates which are currently selected in the graph view of the GUI.
+
+        :returns: List of currently selected gates.
+        :rtype: list[hal_py.gate]
+)");
+
+py_gui_api.def("get_selected_nets", &gui_api::get_selected_nets, R"(
+        Get the nets which are currently selected in the graph view of the GUI.
+
+        :returns: List of currently selected nets.
+        :rtype: list[hal_py.net]
+)");
+
+py_gui_api.def("get_selected_modules", &gui_api::get_selected_modules, R"(
+        Get the modules which are currently selected in the graph view of the GUI.
+
+        :returns: List of currently selected modules.
+        :rtype: list[hal_py.module]
+)");
+
+py_gui_api.def("get_selected_items", &gui_api::get_selected_items, R"(
+        Get all selected items which are currently selected in the graph view of the GUI.
+
+        :returns: Tuple of currently selected items.
+        :rtype: tuple(hal_py.gate, hal_py.net, hal_py.module)
+)");
+
+py_gui_api.def("print_selected_gates", &gui_api::print_selected_gates, R"(
+        Prints id and name of all selected gates to the python console.
+)");
+
+py_gui_api.def("print_selected_nets", &gui_api::print_selected_nets, R"(
+        Prints id and name of all selected nets to the python console.
+)");
+
+py_gui_api.def("print_selected_modules", &gui_api::print_selected_modules, R"(
+        Prints id and name of all selected modules to the python console.
+)");
+
+py_gui_api.def("print_selected_items", &gui_api::print_selected_items, R"(
+        Prints id and name of all selected gates, nets and modules to the python console.
+)");
+
+py_gui_api.def("select_gate", py::overload_cast<u32, bool>(&gui_api::select_gate), py::arg("gate_id"), py::arg("clear_current_selection") = true, R"(
+        Select the gate with id 'gate_id' in the graph view of the GUI.
+        If 'clear_current_selection' is false, the gate with the id 'gate_id' will be added to the currently existing selection.
+
+        :param int gate_id: The gate id of the gate to be selected.
+        :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the gate.
+)");
+
+py_gui_api.def("select_gate", py::overload_cast<std::shared_ptr<gate>, bool>(&gui_api::select_gate), py::arg("gate"), py::arg("clear_current_selection") = true, R"(
+        Select the gate in the graph view of the GUI.
+        If 'clear_current_selection' is false, the gate will be added to the currently existing selection.
+
+        :param hal_py.gate gate: The gate to be selected.
+        :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the gate.
+)");
+
+py_gui_api.def("select_gate", py::overload_cast<std::vector<u32>, bool>(&gui_api::select_gate), py::arg("gate_ids"), py::arg("clear_current_selection") = true, R"(
+        Select the gates with the ids in list 'gate_ids' in the graph view of the GUI.
+        If 'clear_current_selection' is false, the gate with the id 'gate_id' will be added to the currently existing selection.
+
+        :param list[int] gate_ids: List of gate ids of the gates to be selected.
+        :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the gates.
+)");
+
+py_gui_api.def("select_gate", py::overload_cast<std::vector<std::shared_ptr<gate>>, bool>(&gui_api::select_gate), py::arg("gates"), py::arg("clear_current_selection") = true, R"(
+        Select the gates in the graph view of the GUI.
+        If 'clear_current_selection' is false, the gates will be added to the currently existing selection.
+
+        :param list[hal_py.gate] gates: The gates to be selected.
+        :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the gates.
+)");
+
+py_gui_api.def("select_net", py::overload_cast<u32, bool>(&gui_api::select_net), py::arg("net_id"), py::arg("clear_current_selection") = true, R"(
+        Select the net with id 'net_id' in the graph view of the GUI.
+        If 'clear_current_selection' is false, the net with the id 'net_id' will be added to the currently existing selection.
+
+        :param int net_id: The net id of the net to be selected.
+        :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the net.
+)");
+
+py_gui_api.def("select_net", py::overload_cast<std::shared_ptr<net>, bool>(&gui_api::select_net), py::arg("net"), py::arg("clear_current_selection") = true, R"(
+        Select the net in the graph view of the GUI.
+        If 'clear_current_selection' is false, the net will be added to the currently existing selection.
+
+        :param hal_py.net net: The net to be selected.
+        :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the net.
+)");
+
+py_gui_api.def("select_net", py::overload_cast<std::vector<u32>, bool>(&gui_api::select_net), py::arg("net_ids"), py::arg("clear_current_selection") = true, R"(
+        Select the nets with the ids in list 'net_ids' in the graph view of the GUI.
+        If 'clear_current_selection' is false, the net with the id 'net_id' will be added to the currently existing selection.
+
+        :param list[int] net_ids: List of net ids of the nets to be selected.
+        :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the nets.
+)");
+
+py_gui_api.def("select_net", py::overload_cast<std::vector<std::shared_ptr<net>>, bool>(&gui_api::select_net), py::arg("nets"), py::arg("clear_current_selection") = true, R"(
+        Select the nets in the graph view of the GUI.
+        If 'clear_current_selection' is false, the nets will be added to the currently existing selection.
+
+        :param list[hal_py.net] nets: The nets to be selected.
+        :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the nets.
+)");
+
+py_gui_api.def("select_module", py::overload_cast<u32, bool>(&gui_api::select_module), py::arg("module_id"), py::arg("clear_current_selection") = true, R"(
+        Select the module with id 'module_id' in the graph view of the GUI.
+        If 'clear_current_selection' is false, the module with the id 'module_id' will be added to the currently existing selection.
+
+        :param int module_id: The module id of the module to be selected.
+        :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the module.
+)");
+
+py_gui_api.def("select_module", py::overload_cast<std::shared_ptr<module>, bool>(&gui_api::select_module), py::arg("module"), py::arg("clear_current_selection") = true, R"(
+        Select the module in the graph view of the GUI.
+        If 'clear_current_selection' is false, the module will be added to the currently existing selection.
+
+        :param hal_py.module module: The module to be selected.
+        :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the module.
+)");
+
+py_gui_api.def("select_module", py::overload_cast<std::vector<u32>, bool>(&gui_api::select_module), py::arg("module_ids"), py::arg("clear_current_selection") = true, R"(
+        Select the modules with the ids in list 'module_ids' in the graph view of the GUI.
+        If 'clear_current_selection' is false, the module with the id 'module_id' will be added to the currently existing selection.
+
+        :param list[int] module_ids: List of module ids of the modules to be selected.
+        :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the modules.
+)");
+
+py_gui_api.def("select_module", py::overload_cast<std::vector<std::shared_ptr<module>>, bool>(&gui_api::select_module), py::arg("modules"), py::arg("clear_current_selection") = true, R"(
+        Select the modules in the graph view of the GUI.
+        If 'clear_current_selection' is false, the modules will be added to the currently existing selection.
+
+        :param list[hal_py.module] modules: The modules to be selected.
+        :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the modules.
+)");
+
+py_gui_api.def("select", py::overload_cast<std::shared_ptr<gate>, bool>(&gui_api::select), py::arg("gate"), py::arg("clear_current_selection") = true, R"(
+        Select the gate in the graph view of the GUI.
+        If 'clear_current_selection' is false, the gate will be added to the currently existing selection.
+
+        :param hal_py.gate gate: The gate to be selected.
+        :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the gate.
+)");
+
+py_gui_api.def("select", py::overload_cast<std::shared_ptr<net>, bool>(&gui_api::select), py::arg("net"), py::arg("clear_current_selection") = true, R"(
+        Select the net in the graph view of the GUI.
+        If 'clear_current_selection' is false, the net will be added to the currently existing selection.
+
+        :param hal_py.net net: The net to be selected.
+        :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the net.
+)");
+
+py_gui_api.def("select", py::overload_cast<std::shared_ptr<module>, bool>(&gui_api::select), py::arg("module"), py::arg("clear_current_selection") = true, R"(
+        Select the module in the graph view of the GUI.
+        If 'clear_current_selection' is false, the module will be added to the currently existing selection.
+
+        :param hal_py.module module: The module to be selected.
+        :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the module.
+)");
+
+py_gui_api.def("select", py::overload_cast<std::vector<std::shared_ptr<gate>>, bool>(&gui_api::select), py::arg("gates"), py::arg("clear_current_selection") = true, R"(
+        Select the gates in the graph view of the GUI.
+        If 'clear_current_selection' is false, the gates will be added to the currently existing selection.
+
+        :param list[hal_py.gate] gates: The gates to be selected.
+        :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the gates.
+)");
+
+py_gui_api.def("select", py::overload_cast<std::vector<std::shared_ptr<net>>, bool>(&gui_api::select), py::arg("nets"), py::arg("clear_current_selection") = true, R"(
+        Select the nets in the graph view of the GUI.
+        If 'clear_current_selection' is false, the nets will be added to the currently existing selection.
+
+        :param list[hal_py.net] nets: The nets to be selected.
+        :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the nets.
+)");
+
+py_gui_api.def("select", py::overload_cast<std::vector<std::shared_ptr<module>>, bool>(&gui_api::select), py::arg("modules"), py::arg("clear_current_selection") = true, R"(
+        Select the modules in the graph view of the GUI.
+        If 'clear_current_selection' is false, the modules will be added to the currently existing selection.
+
+        :param list[hal_py.module] modules: The modules to be selected.
+        :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the modules.
+)");
+
+py_gui_api.def("select", py::overload_cast<std::vector<u32>, std::vector<u32>, std::vector<u32>, bool>(&gui_api::select), py::arg("gate_ids"), py::arg("net_ids"), py::arg("module_ids"), py::arg("clear_current_selection") = true, R"(
+        Select the gates, nets and modules with the passed ids in the graph view of the GUI.
+        If 'clear_current_selection' is false, the gates, nets and modules will be added to the currently existing selection.
+
+        :param list[hal_py.gate] gates: The ids of the gates to be selected.
+        :param list[hal_py.net] nets: The ids of the nets to be selected.
+        :param list[hal_py.module] modules: The ids of the modules to be selected.
+        :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the modules.
+)");
+
+py_gui_api.def("select", py::overload_cast<std::vector<std::shared_ptr<gate>>, std::vector<std::shared_ptr<net>>, std::vector<std::shared_ptr<module>>, bool>(&gui_api::select), py::arg("gates"), py::arg("nets"), py::arg("modules"), py::arg("clear_current_selection") = true, R"(
+        Select the gates, nets and modules in the graph view of the GUI.
+        If 'clear_current_selection' is false, the gates, nets and modules will be added to the currently existing selection.
+
+        :param list[hal_py.gate] gates: The gates to be selected.
+        :param list[hal_py.net] nets: The nets to be selected.
+        :param list[hal_py.module] modules: The modules to be selected.
+        :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the modules.
+)");
+
+py_gui_api.def("clear_gate", py::overload_cast<u32>(&gui_api::clear_gate), py::arg("gate_id"), R"(
+        Clear the gate with id 'gate_id' in the graph view of the GUI.
+
+        :param int gate_id: The gate id of the gate to be selected.
+)");
+
+py_gui_api.def("clear_gate", py::overload_cast<std::shared_ptr<gate>>(&gui_api::clear_gate), py::arg("gate"), R"(
+        Clear the gate in the graph view of the GUI.
+
+        :param hal_py.gate gate: The gate to be cleared.
+)");
+
+py_gui_api.def("clear_gate", py::overload_cast<std::vector<u32>>(&gui_api::clear_gate), py::arg("gate_ids"), R"(
+        Clear the gates with the ids in list 'gate_ids' in the graph view of the GUI.
+
+        :param list[int] gate_ids: List of gate ids of the gates to be cleared.
+)");
+
+py_gui_api.def("clear_gate", py::overload_cast<std::vector<std::shared_ptr<gate>>>(&gui_api::clear_gate), py::arg("gates"), R"(
+        Clear the gates in the graph view of the GUI.
+
+        :param list[hal_py.gate] gates: The gates to be cleared.
+)");
+
+py_gui_api.def("clear_net", py::overload_cast<u32>(&gui_api::clear_net), py::arg("net_id"), R"(
+        Clear the net with id 'net_id' in the graph view of the GUI.
+
+        :param int net_id: The net id of the net to be selected.
+)");
+
+py_gui_api.def("clear_net", py::overload_cast<std::shared_ptr<net>>(&gui_api::clear_net), py::arg("net"), R"(
+        Clear the net in the graph view of the GUI.
+
+        :param hal_py.net net: The net to be cleared.
+)");
+
+py_gui_api.def("clear_net", py::overload_cast<std::vector<u32>>(&gui_api::clear_net), py::arg("net_ids"), R"(
+        Clear the nets with the ids in list 'net_ids' in the graph view of the GUI.
+
+        :param list[int] net_ids: List of net ids of the nets to be cleared.
+)");
+
+py_gui_api.def("clear_net", py::overload_cast<std::vector<std::shared_ptr<net>>>(&gui_api::clear_net), py::arg("nets"), R"(
+        Clear the nets in the graph view of the GUI.
+
+        :param list[hal_py.net] nets: The nets to be cleared.
+)");
+
+py_gui_api.def("clear_module", py::overload_cast<u32>(&gui_api::clear_module), py::arg("module_id"), R"(
+        Clear the module with id 'module_id' in the graph view of the GUI.
+
+        :param int module_id: The module id of the module to be selected.
+)");
+
+py_gui_api.def("clear_module", py::overload_cast<std::shared_ptr<module>>(&gui_api::clear_module), py::arg("module"), R"(
+        Clear the module in the graph view of the GUI.
+
+        :param hal_py.module module: The module to be cleared.
+)");
+
+py_gui_api.def("clear_module", py::overload_cast<std::vector<u32>>(&gui_api::clear_module), py::arg("module_ids"), R"(
+        Clear the modules with the ids in list 'module_ids' in the graph view of the GUI.
+
+        :param list[int] module_ids: List of module ids of the modules to be cleared.
+)");
+
+py_gui_api.def("clear_module", py::overload_cast<std::vector<std::shared_ptr<module>>>(&gui_api::clear_module), py::arg("modules"), R"(
+        Clear the modules in the graph view of the GUI.
+
+        :param list[hal_py.module] modules: The modules to be cleared.
+)");
+
+py_gui_api.def("clear", py::overload_cast<std::shared_ptr<gate>>(&gui_api::clear), py::arg("gate"), R"(
+        Clear the gate in the graph view of the GUI.
+
+        :param hal_py.gate gate: The gate to be cleared.
+)");
+
+py_gui_api.def("clear", py::overload_cast<std::shared_ptr<net>>(&gui_api::clear), py::arg("net"), R"(
+        Clear the net in the graph view of the GUI.
+
+        :param hal_py.net net: The net to be cleared.
+)");
+
+py_gui_api.def("clear", py::overload_cast<std::shared_ptr<module>>(&gui_api::clear), py::arg("module"), R"(
+        Clear the module in the graph view of the GUI.
+
+        :param hal_py.module module: The module to be cleared.
+)");
+
+py_gui_api.def("clear", py::overload_cast<std::vector<std::shared_ptr<gate>>>(&gui_api::clear), py::arg("gates"), R"(
+        Clear the gates in the graph view of the GUI.
+
+        :param list[hal_py.gate] gates: The gates to be cleared.
+)");
+
+py_gui_api.def("clear", py::overload_cast<std::vector<std::shared_ptr<net>>>(&gui_api::clear), py::arg("nets"), R"(
+        Clear the nets in the graph view of the GUI.
+
+        :param list[hal_py.net] nets: The nets to be cleared.
+)");
+
+py_gui_api.def("clear", py::overload_cast<std::vector<std::shared_ptr<module>>>(&gui_api::clear), py::arg("modules"), R"(
+        Clear the modules in the graph view of the GUI.
+
+        :param list[hal_py.module] modules: The modules to be cleared.
+)");
+
+py_gui_api.def("clear", py::overload_cast<std::vector<u32>, std::vector<u32>, std::vector<u32>>(&gui_api::clear), py::arg("gate_ids"), py::arg("net_ids"), py::arg("module_ids"), R"(
+        Clear the gates, nets and modules with the passed ids in the graph view of the GUI.
+
+        :param list[hal_py.gate] gates: The ids of the gates to be cleared.
+        :param list[hal_py.net] nets: The ids of the nets to be cleared.
+        :param list[hal_py.module] modules: The ids of the modules to be cleared.
+)");
+
+py_gui_api.def("clear", py::overload_cast<std::vector<std::shared_ptr<gate>>, std::vector<std::shared_ptr<net>>, std::vector<std::shared_ptr<module>>>(&gui_api::clear), py::arg("gates"), py::arg("nets"), py::arg("modules"), R"(
+        Clear the gates, nets and modules in the graph view of the GUI.
+
+        :param list[hal_py.gate] gates: The gates to be cleared.
+        :param list[hal_py.net] nets: The nets to be cleared.
+        :param list[hal_py.module] modules: The modules to be cleared.
+)");
+
+py_gui_api.def("clear", py::overload_cast<>(&gui_api::clear), R"(
+        Clear all gates, nets and modules in the graph view of the GUI.
 )");
 
 #ifndef PYBIND11_MODULE

--- a/src/python-binding/python_definitions.cpp
+++ b/src/python-binding/python_definitions.cpp
@@ -2362,7 +2362,7 @@ py_gui_api.def("select_gate", py::overload_cast<u32, bool>(&gui_api::select_gate
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the gate.
 )");
 
-py_gui_api.def("select_gate", py::overload_cast<const std::shared_ptr<gate>, bool>(&gui_api::select_gate), py::arg("gate"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select_gate", py::overload_cast<const std::shared_ptr<gate>&, bool>(&gui_api::select_gate), py::arg("gate"), py::arg("clear_current_selection") = true, R"(
         Select the gate in the graph view of the GUI.
         If 'clear_current_selection' is false, the gate will be added to the currently existing selection.
 
@@ -2394,7 +2394,7 @@ py_gui_api.def("select_net", py::overload_cast<u32, bool>(&gui_api::select_net),
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the net.
 )");
 
-py_gui_api.def("select_net", py::overload_cast<const std::shared_ptr<net>, bool>(&gui_api::select_net), py::arg("net"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select_net", py::overload_cast<const std::shared_ptr<net>&, bool>(&gui_api::select_net), py::arg("net"), py::arg("clear_current_selection") = true, R"(
         Select the net in the graph view of the GUI.
         If 'clear_current_selection' is false, the net will be added to the currently existing selection.
 
@@ -2426,7 +2426,7 @@ py_gui_api.def("select_module", py::overload_cast<u32, bool>(&gui_api::select_mo
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the module.
 )");
 
-py_gui_api.def("select_module", py::overload_cast<const std::shared_ptr<module>, bool>(&gui_api::select_module), py::arg("module"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select_module", py::overload_cast<const std::shared_ptr<module>&, bool>(&gui_api::select_module), py::arg("module"), py::arg("clear_current_selection") = true, R"(
         Select the module in the graph view of the GUI.
         If 'clear_current_selection' is false, the module will be added to the currently existing selection.
 
@@ -2450,7 +2450,7 @@ py_gui_api.def("select_module", py::overload_cast<const std::vector<std::shared_
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the modules.
 )");
 
-py_gui_api.def("select", py::overload_cast<const std::shared_ptr<gate>, bool>(&gui_api::select), py::arg("gate"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select", py::overload_cast<const std::shared_ptr<gate>&, bool>(&gui_api::select), py::arg("gate"), py::arg("clear_current_selection") = true, R"(
         Select the gate in the graph view of the GUI.
         If 'clear_current_selection' is false, the gate will be added to the currently existing selection.
 
@@ -2458,7 +2458,7 @@ py_gui_api.def("select", py::overload_cast<const std::shared_ptr<gate>, bool>(&g
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the gate.
 )");
 
-py_gui_api.def("select", py::overload_cast<const std::shared_ptr<net>, bool>(&gui_api::select), py::arg("net"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select", py::overload_cast<const std::shared_ptr<net>&, bool>(&gui_api::select), py::arg("net"), py::arg("clear_current_selection") = true, R"(
         Select the net in the graph view of the GUI.
         If 'clear_current_selection' is false, the net will be added to the currently existing selection.
 
@@ -2466,7 +2466,7 @@ py_gui_api.def("select", py::overload_cast<const std::shared_ptr<net>, bool>(&gu
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the net.
 )");
 
-py_gui_api.def("select", py::overload_cast<const std::shared_ptr<module>, bool>(&gui_api::select), py::arg("module"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select", py::overload_cast<const std::shared_ptr<module>&, bool>(&gui_api::select), py::arg("module"), py::arg("clear_current_selection") = true, R"(
         Select the module in the graph view of the GUI.
         If 'clear_current_selection' is false, the module will be added to the currently existing selection.
 
@@ -2524,7 +2524,7 @@ py_gui_api.def("deselect_gate", py::overload_cast<u32>(&gui_api::deselect_gate),
         :param int gate_id: The gate id of the gate to be selected.
 )");
 
-py_gui_api.def("deselect_gate", py::overload_cast<const std::shared_ptr<gate>>(&gui_api::deselect_gate), py::arg("gate"), R"(
+py_gui_api.def("deselect_gate", py::overload_cast<const std::shared_ptr<gate>&>(&gui_api::deselect_gate), py::arg("gate"), R"(
         Deselect the gate in the graph view of the GUI.
 
         :param hal_py.gate gate: The gate to be deselected.
@@ -2548,7 +2548,7 @@ py_gui_api.def("deselect_net", py::overload_cast<u32>(&gui_api::deselect_net), p
         :param int net_id: The net id of the net to be selected.
 )");
 
-py_gui_api.def("deselect_net", py::overload_cast<const std::shared_ptr<net>>(&gui_api::deselect_net), py::arg("net"), R"(
+py_gui_api.def("deselect_net", py::overload_cast<const std::shared_ptr<net>&>(&gui_api::deselect_net), py::arg("net"), R"(
         Deselect the net in the graph view of the GUI.
 
         :param hal_py.net net: The net to be deselected.
@@ -2572,7 +2572,7 @@ py_gui_api.def("deselect_module", py::overload_cast<u32>(&gui_api::deselect_modu
         :param int module_id: The module id of the module to be selected.
 )");
 
-py_gui_api.def("deselect_module", py::overload_cast<const std::shared_ptr<module>>(&gui_api::deselect_module), py::arg("module"), R"(
+py_gui_api.def("deselect_module", py::overload_cast<const std::shared_ptr<module>&>(&gui_api::deselect_module), py::arg("module"), R"(
         Deselect the module in the graph view of the GUI.
 
         :param hal_py.module module: The module to be deselected.
@@ -2590,19 +2590,19 @@ py_gui_api.def("deselect_module", py::overload_cast<const std::vector<std::share
         :param list[hal_py.module] modules: The modules to be deselected.
 )");
 
-py_gui_api.def("deselect", py::overload_cast<const std::shared_ptr<gate>>(&gui_api::deselect), py::arg("gate"), R"(
+py_gui_api.def("deselect", py::overload_cast<const std::shared_ptr<gate>&>(&gui_api::deselect), py::arg("gate"), R"(
         Deselect the gate in the graph view of the GUI.
 
         :param hal_py.gate gate: The gate to be deselected.
 )");
 
-py_gui_api.def("deselect", py::overload_cast<const std::shared_ptr<net>>(&gui_api::deselect), py::arg("net"), R"(
+py_gui_api.def("deselect", py::overload_cast<const std::shared_ptr<net>&>(&gui_api::deselect), py::arg("net"), R"(
         Deselect the net in the graph view of the GUI.
 
         :param hal_py.net net: The net to be deselected.
 )");
 
-py_gui_api.def("deselect", py::overload_cast<const std::shared_ptr<module>>(&gui_api::deselect), py::arg("module"), R"(
+py_gui_api.def("deselect", py::overload_cast<const std::shared_ptr<module>&>(&gui_api::deselect), py::arg("module"), R"(
         Deselect the module in the graph view of the GUI.
 
         :param hal_py.module module: The module to be deselected.

--- a/src/python-binding/python_definitions.cpp
+++ b/src/python-binding/python_definitions.cpp
@@ -2336,6 +2336,7 @@ py_gui_api.def("get_selected_items", &gui_api::get_selected_items, R"(
         :rtype: tuple(hal_py.gate, hal_py.net, hal_py.module)
 )");
 
+/*
 py_gui_api.def("print_selected_gates", &gui_api::print_selected_gates, R"(
         Prints id and name of all selected gates to the python console.
 )");
@@ -2351,6 +2352,7 @@ py_gui_api.def("print_selected_modules", &gui_api::print_selected_modules, R"(
 py_gui_api.def("print_selected_items", &gui_api::print_selected_items, R"(
         Prints id and name of all selected gates, nets and modules to the python console.
 )");
+*/
 
 py_gui_api.def("select_gate", py::overload_cast<u32, bool>(&gui_api::select_gate), py::arg("gate_id"), py::arg("clear_current_selection") = true, R"(
         Select the gate with id 'gate_id' in the graph view of the GUI.
@@ -2360,7 +2362,7 @@ py_gui_api.def("select_gate", py::overload_cast<u32, bool>(&gui_api::select_gate
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the gate.
 )");
 
-py_gui_api.def("select_gate", py::overload_cast<std::shared_ptr<gate>, bool>(&gui_api::select_gate), py::arg("gate"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select_gate", py::overload_cast<const std::shared_ptr<gate>, bool>(&gui_api::select_gate), py::arg("gate"), py::arg("clear_current_selection") = true, R"(
         Select the gate in the graph view of the GUI.
         If 'clear_current_selection' is false, the gate will be added to the currently existing selection.
 
@@ -2368,7 +2370,7 @@ py_gui_api.def("select_gate", py::overload_cast<std::shared_ptr<gate>, bool>(&gu
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the gate.
 )");
 
-py_gui_api.def("select_gate", py::overload_cast<std::vector<u32>, bool>(&gui_api::select_gate), py::arg("gate_ids"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select_gate", py::overload_cast<const std::vector<u32>&, bool>(&gui_api::select_gate), py::arg("gate_ids"), py::arg("clear_current_selection") = true, R"(
         Select the gates with the ids in list 'gate_ids' in the graph view of the GUI.
         If 'clear_current_selection' is false, the gate with the id 'gate_id' will be added to the currently existing selection.
 
@@ -2376,7 +2378,7 @@ py_gui_api.def("select_gate", py::overload_cast<std::vector<u32>, bool>(&gui_api
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the gates.
 )");
 
-py_gui_api.def("select_gate", py::overload_cast<std::vector<std::shared_ptr<gate>>, bool>(&gui_api::select_gate), py::arg("gates"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select_gate", py::overload_cast<const std::vector<std::shared_ptr<gate>>&, bool>(&gui_api::select_gate), py::arg("gates"), py::arg("clear_current_selection") = true, R"(
         Select the gates in the graph view of the GUI.
         If 'clear_current_selection' is false, the gates will be added to the currently existing selection.
 
@@ -2392,7 +2394,7 @@ py_gui_api.def("select_net", py::overload_cast<u32, bool>(&gui_api::select_net),
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the net.
 )");
 
-py_gui_api.def("select_net", py::overload_cast<std::shared_ptr<net>, bool>(&gui_api::select_net), py::arg("net"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select_net", py::overload_cast<const std::shared_ptr<net>, bool>(&gui_api::select_net), py::arg("net"), py::arg("clear_current_selection") = true, R"(
         Select the net in the graph view of the GUI.
         If 'clear_current_selection' is false, the net will be added to the currently existing selection.
 
@@ -2400,7 +2402,7 @@ py_gui_api.def("select_net", py::overload_cast<std::shared_ptr<net>, bool>(&gui_
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the net.
 )");
 
-py_gui_api.def("select_net", py::overload_cast<std::vector<u32>, bool>(&gui_api::select_net), py::arg("net_ids"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select_net", py::overload_cast<const std::vector<u32>&, bool>(&gui_api::select_net), py::arg("net_ids"), py::arg("clear_current_selection") = true, R"(
         Select the nets with the ids in list 'net_ids' in the graph view of the GUI.
         If 'clear_current_selection' is false, the net with the id 'net_id' will be added to the currently existing selection.
 
@@ -2408,7 +2410,7 @@ py_gui_api.def("select_net", py::overload_cast<std::vector<u32>, bool>(&gui_api:
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the nets.
 )");
 
-py_gui_api.def("select_net", py::overload_cast<std::vector<std::shared_ptr<net>>, bool>(&gui_api::select_net), py::arg("nets"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select_net", py::overload_cast<const std::vector<std::shared_ptr<net>>&, bool>(&gui_api::select_net), py::arg("nets"), py::arg("clear_current_selection") = true, R"(
         Select the nets in the graph view of the GUI.
         If 'clear_current_selection' is false, the nets will be added to the currently existing selection.
 
@@ -2424,7 +2426,7 @@ py_gui_api.def("select_module", py::overload_cast<u32, bool>(&gui_api::select_mo
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the module.
 )");
 
-py_gui_api.def("select_module", py::overload_cast<std::shared_ptr<module>, bool>(&gui_api::select_module), py::arg("module"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select_module", py::overload_cast<const std::shared_ptr<module>, bool>(&gui_api::select_module), py::arg("module"), py::arg("clear_current_selection") = true, R"(
         Select the module in the graph view of the GUI.
         If 'clear_current_selection' is false, the module will be added to the currently existing selection.
 
@@ -2432,7 +2434,7 @@ py_gui_api.def("select_module", py::overload_cast<std::shared_ptr<module>, bool>
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the module.
 )");
 
-py_gui_api.def("select_module", py::overload_cast<std::vector<u32>, bool>(&gui_api::select_module), py::arg("module_ids"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select_module", py::overload_cast<const std::vector<u32>&, bool>(&gui_api::select_module), py::arg("module_ids"), py::arg("clear_current_selection") = true, R"(
         Select the modules with the ids in list 'module_ids' in the graph view of the GUI.
         If 'clear_current_selection' is false, the module with the id 'module_id' will be added to the currently existing selection.
 
@@ -2440,7 +2442,7 @@ py_gui_api.def("select_module", py::overload_cast<std::vector<u32>, bool>(&gui_a
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the modules.
 )");
 
-py_gui_api.def("select_module", py::overload_cast<std::vector<std::shared_ptr<module>>, bool>(&gui_api::select_module), py::arg("modules"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select_module", py::overload_cast<const std::vector<std::shared_ptr<module>>&, bool>(&gui_api::select_module), py::arg("modules"), py::arg("clear_current_selection") = true, R"(
         Select the modules in the graph view of the GUI.
         If 'clear_current_selection' is false, the modules will be added to the currently existing selection.
 
@@ -2448,7 +2450,7 @@ py_gui_api.def("select_module", py::overload_cast<std::vector<std::shared_ptr<mo
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the modules.
 )");
 
-py_gui_api.def("select", py::overload_cast<std::shared_ptr<gate>, bool>(&gui_api::select), py::arg("gate"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select", py::overload_cast<const std::shared_ptr<gate>, bool>(&gui_api::select), py::arg("gate"), py::arg("clear_current_selection") = true, R"(
         Select the gate in the graph view of the GUI.
         If 'clear_current_selection' is false, the gate will be added to the currently existing selection.
 
@@ -2456,7 +2458,7 @@ py_gui_api.def("select", py::overload_cast<std::shared_ptr<gate>, bool>(&gui_api
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the gate.
 )");
 
-py_gui_api.def("select", py::overload_cast<std::shared_ptr<net>, bool>(&gui_api::select), py::arg("net"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select", py::overload_cast<const std::shared_ptr<net>, bool>(&gui_api::select), py::arg("net"), py::arg("clear_current_selection") = true, R"(
         Select the net in the graph view of the GUI.
         If 'clear_current_selection' is false, the net will be added to the currently existing selection.
 
@@ -2464,7 +2466,7 @@ py_gui_api.def("select", py::overload_cast<std::shared_ptr<net>, bool>(&gui_api:
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the net.
 )");
 
-py_gui_api.def("select", py::overload_cast<std::shared_ptr<module>, bool>(&gui_api::select), py::arg("module"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select", py::overload_cast<const std::shared_ptr<module>, bool>(&gui_api::select), py::arg("module"), py::arg("clear_current_selection") = true, R"(
         Select the module in the graph view of the GUI.
         If 'clear_current_selection' is false, the module will be added to the currently existing selection.
 
@@ -2472,7 +2474,7 @@ py_gui_api.def("select", py::overload_cast<std::shared_ptr<module>, bool>(&gui_a
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the module.
 )");
 
-py_gui_api.def("select", py::overload_cast<std::vector<std::shared_ptr<gate>>, bool>(&gui_api::select), py::arg("gates"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select", py::overload_cast<const std::vector<std::shared_ptr<gate>>&, bool>(&gui_api::select), py::arg("gates"), py::arg("clear_current_selection") = true, R"(
         Select the gates in the graph view of the GUI.
         If 'clear_current_selection' is false, the gates will be added to the currently existing selection.
 
@@ -2480,7 +2482,7 @@ py_gui_api.def("select", py::overload_cast<std::vector<std::shared_ptr<gate>>, b
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the gates.
 )");
 
-py_gui_api.def("select", py::overload_cast<std::vector<std::shared_ptr<net>>, bool>(&gui_api::select), py::arg("nets"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select", py::overload_cast<const std::vector<std::shared_ptr<net>>&, bool>(&gui_api::select), py::arg("nets"), py::arg("clear_current_selection") = true, R"(
         Select the nets in the graph view of the GUI.
         If 'clear_current_selection' is false, the nets will be added to the currently existing selection.
 
@@ -2488,7 +2490,7 @@ py_gui_api.def("select", py::overload_cast<std::vector<std::shared_ptr<net>>, bo
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the nets.
 )");
 
-py_gui_api.def("select", py::overload_cast<std::vector<std::shared_ptr<module>>, bool>(&gui_api::select), py::arg("modules"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select", py::overload_cast<const std::vector<std::shared_ptr<module>>&, bool>(&gui_api::select), py::arg("modules"), py::arg("clear_current_selection") = true, R"(
         Select the modules in the graph view of the GUI.
         If 'clear_current_selection' is false, the modules will be added to the currently existing selection.
 
@@ -2496,7 +2498,7 @@ py_gui_api.def("select", py::overload_cast<std::vector<std::shared_ptr<module>>,
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the modules.
 )");
 
-py_gui_api.def("select", py::overload_cast<std::vector<u32>, std::vector<u32>, std::vector<u32>, bool>(&gui_api::select), py::arg("gate_ids"), py::arg("net_ids"), py::arg("module_ids"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select", py::overload_cast<const std::vector<u32>&, const std::vector<u32>&, const std::vector<u32>&, bool>(&gui_api::select), py::arg("gate_ids"), py::arg("net_ids"), py::arg("module_ids"), py::arg("clear_current_selection") = true, R"(
         Select the gates, nets and modules with the passed ids in the graph view of the GUI.
         If 'clear_current_selection' is false, the gates, nets and modules will be added to the currently existing selection.
 
@@ -2506,7 +2508,7 @@ py_gui_api.def("select", py::overload_cast<std::vector<u32>, std::vector<u32>, s
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the modules.
 )");
 
-py_gui_api.def("select", py::overload_cast<std::vector<std::shared_ptr<gate>>, std::vector<std::shared_ptr<net>>, std::vector<std::shared_ptr<module>>, bool>(&gui_api::select), py::arg("gates"), py::arg("nets"), py::arg("modules"), py::arg("clear_current_selection") = true, R"(
+py_gui_api.def("select", py::overload_cast<const std::vector<std::shared_ptr<gate>>&, const std::vector<std::shared_ptr<net>>&, const std::vector<std::shared_ptr<module>>&, bool>(&gui_api::select), py::arg("gates"), py::arg("nets"), py::arg("modules"), py::arg("clear_current_selection") = true, R"(
         Select the gates, nets and modules in the graph view of the GUI.
         If 'clear_current_selection' is false, the gates, nets and modules will be added to the currently existing selection.
 
@@ -2516,132 +2518,132 @@ py_gui_api.def("select", py::overload_cast<std::vector<std::shared_ptr<gate>>, s
         :param bool clear_current_selection: Determines if the previous selection gets cleared before the selection of the modules.
 )");
 
-py_gui_api.def("clear_gate", py::overload_cast<u32>(&gui_api::clear_gate), py::arg("gate_id"), R"(
-        Clear the gate with id 'gate_id' in the graph view of the GUI.
+py_gui_api.def("deselect_gate", py::overload_cast<u32>(&gui_api::deselect_gate), py::arg("gate_id"), R"(
+        Deselect the gate with id 'gate_id' in the graph view of the GUI.
 
         :param int gate_id: The gate id of the gate to be selected.
 )");
 
-py_gui_api.def("clear_gate", py::overload_cast<std::shared_ptr<gate>>(&gui_api::clear_gate), py::arg("gate"), R"(
-        Clear the gate in the graph view of the GUI.
+py_gui_api.def("deselect_gate", py::overload_cast<const std::shared_ptr<gate>>(&gui_api::deselect_gate), py::arg("gate"), R"(
+        Deselect the gate in the graph view of the GUI.
 
-        :param hal_py.gate gate: The gate to be cleared.
+        :param hal_py.gate gate: The gate to be deselected.
 )");
 
-py_gui_api.def("clear_gate", py::overload_cast<std::vector<u32>>(&gui_api::clear_gate), py::arg("gate_ids"), R"(
-        Clear the gates with the ids in list 'gate_ids' in the graph view of the GUI.
+py_gui_api.def("deselect_gate", py::overload_cast<const std::vector<u32>&>(&gui_api::deselect_gate), py::arg("gate_ids"), R"(
+        Deselect the gates with the ids in list 'gate_ids' in the graph view of the GUI.
 
-        :param list[int] gate_ids: List of gate ids of the gates to be cleared.
+        :param list[int] gate_ids: List of gate ids of the gates to be deselected.
 )");
 
-py_gui_api.def("clear_gate", py::overload_cast<std::vector<std::shared_ptr<gate>>>(&gui_api::clear_gate), py::arg("gates"), R"(
-        Clear the gates in the graph view of the GUI.
+py_gui_api.def("deselect_gate", py::overload_cast<const std::vector<std::shared_ptr<gate>>&>(&gui_api::deselect_gate), py::arg("gates"), R"(
+        Deselect the gates in the graph view of the GUI.
 
-        :param list[hal_py.gate] gates: The gates to be cleared.
+        :param list[hal_py.gate] gates: The gates to be deselected.
 )");
 
-py_gui_api.def("clear_net", py::overload_cast<u32>(&gui_api::clear_net), py::arg("net_id"), R"(
-        Clear the net with id 'net_id' in the graph view of the GUI.
+py_gui_api.def("deselect_net", py::overload_cast<u32>(&gui_api::deselect_net), py::arg("net_id"), R"(
+        Deselect the net with id 'net_id' in the graph view of the GUI.
 
         :param int net_id: The net id of the net to be selected.
 )");
 
-py_gui_api.def("clear_net", py::overload_cast<std::shared_ptr<net>>(&gui_api::clear_net), py::arg("net"), R"(
-        Clear the net in the graph view of the GUI.
+py_gui_api.def("deselect_net", py::overload_cast<const std::shared_ptr<net>>(&gui_api::deselect_net), py::arg("net"), R"(
+        Deselect the net in the graph view of the GUI.
 
-        :param hal_py.net net: The net to be cleared.
+        :param hal_py.net net: The net to be deselected.
 )");
 
-py_gui_api.def("clear_net", py::overload_cast<std::vector<u32>>(&gui_api::clear_net), py::arg("net_ids"), R"(
-        Clear the nets with the ids in list 'net_ids' in the graph view of the GUI.
+py_gui_api.def("deselect_net", py::overload_cast<const std::vector<u32>&>(&gui_api::deselect_net), py::arg("net_ids"), R"(
+        Deselect the nets with the ids in list 'net_ids' in the graph view of the GUI.
 
-        :param list[int] net_ids: List of net ids of the nets to be cleared.
+        :param list[int] net_ids: List of net ids of the nets to be deselected.
 )");
 
-py_gui_api.def("clear_net", py::overload_cast<std::vector<std::shared_ptr<net>>>(&gui_api::clear_net), py::arg("nets"), R"(
-        Clear the nets in the graph view of the GUI.
+py_gui_api.def("deselect_net", py::overload_cast<const std::vector<std::shared_ptr<net>>&>(&gui_api::deselect_net), py::arg("nets"), R"(
+        Deselect the nets in the graph view of the GUI.
 
-        :param list[hal_py.net] nets: The nets to be cleared.
+        :param list[hal_py.net] nets: The nets to be deselected.
 )");
 
-py_gui_api.def("clear_module", py::overload_cast<u32>(&gui_api::clear_module), py::arg("module_id"), R"(
-        Clear the module with id 'module_id' in the graph view of the GUI.
+py_gui_api.def("deselect_module", py::overload_cast<u32>(&gui_api::deselect_module), py::arg("module_id"), R"(
+        Deselect the module with id 'module_id' in the graph view of the GUI.
 
         :param int module_id: The module id of the module to be selected.
 )");
 
-py_gui_api.def("clear_module", py::overload_cast<std::shared_ptr<module>>(&gui_api::clear_module), py::arg("module"), R"(
-        Clear the module in the graph view of the GUI.
+py_gui_api.def("deselect_module", py::overload_cast<const std::shared_ptr<module>>(&gui_api::deselect_module), py::arg("module"), R"(
+        Deselect the module in the graph view of the GUI.
 
-        :param hal_py.module module: The module to be cleared.
+        :param hal_py.module module: The module to be deselected.
 )");
 
-py_gui_api.def("clear_module", py::overload_cast<std::vector<u32>>(&gui_api::clear_module), py::arg("module_ids"), R"(
-        Clear the modules with the ids in list 'module_ids' in the graph view of the GUI.
+py_gui_api.def("deselect_module", py::overload_cast<const std::vector<u32>&>(&gui_api::deselect_module), py::arg("module_ids"), R"(
+        Deselect the modules with the ids in list 'module_ids' in the graph view of the GUI.
 
-        :param list[int] module_ids: List of module ids of the modules to be cleared.
+        :param list[int] module_ids: List of module ids of the modules to be deselected.
 )");
 
-py_gui_api.def("clear_module", py::overload_cast<std::vector<std::shared_ptr<module>>>(&gui_api::clear_module), py::arg("modules"), R"(
-        Clear the modules in the graph view of the GUI.
+py_gui_api.def("deselect_module", py::overload_cast<const std::vector<std::shared_ptr<module>>&>(&gui_api::deselect_module), py::arg("modules"), R"(
+        Deselect the modules in the graph view of the GUI.
 
-        :param list[hal_py.module] modules: The modules to be cleared.
+        :param list[hal_py.module] modules: The modules to be deselected.
 )");
 
-py_gui_api.def("clear", py::overload_cast<std::shared_ptr<gate>>(&gui_api::clear), py::arg("gate"), R"(
-        Clear the gate in the graph view of the GUI.
+py_gui_api.def("deselect", py::overload_cast<const std::shared_ptr<gate>>(&gui_api::deselect), py::arg("gate"), R"(
+        Deselect the gate in the graph view of the GUI.
 
-        :param hal_py.gate gate: The gate to be cleared.
+        :param hal_py.gate gate: The gate to be deselected.
 )");
 
-py_gui_api.def("clear", py::overload_cast<std::shared_ptr<net>>(&gui_api::clear), py::arg("net"), R"(
-        Clear the net in the graph view of the GUI.
+py_gui_api.def("deselect", py::overload_cast<const std::shared_ptr<net>>(&gui_api::deselect), py::arg("net"), R"(
+        Deselect the net in the graph view of the GUI.
 
-        :param hal_py.net net: The net to be cleared.
+        :param hal_py.net net: The net to be deselected.
 )");
 
-py_gui_api.def("clear", py::overload_cast<std::shared_ptr<module>>(&gui_api::clear), py::arg("module"), R"(
-        Clear the module in the graph view of the GUI.
+py_gui_api.def("deselect", py::overload_cast<const std::shared_ptr<module>>(&gui_api::deselect), py::arg("module"), R"(
+        Deselect the module in the graph view of the GUI.
 
-        :param hal_py.module module: The module to be cleared.
+        :param hal_py.module module: The module to be deselected.
 )");
 
-py_gui_api.def("clear", py::overload_cast<std::vector<std::shared_ptr<gate>>>(&gui_api::clear), py::arg("gates"), R"(
-        Clear the gates in the graph view of the GUI.
+py_gui_api.def("deselect", py::overload_cast<const std::vector<std::shared_ptr<gate>>&>(&gui_api::deselect), py::arg("gates"), R"(
+        Deselect the gates in the graph view of the GUI.
 
-        :param list[hal_py.gate] gates: The gates to be cleared.
+        :param list[hal_py.gate] gates: The gates to be deselected.
 )");
 
-py_gui_api.def("clear", py::overload_cast<std::vector<std::shared_ptr<net>>>(&gui_api::clear), py::arg("nets"), R"(
-        Clear the nets in the graph view of the GUI.
+py_gui_api.def("deselect", py::overload_cast<const std::vector<std::shared_ptr<net>>&>(&gui_api::deselect), py::arg("nets"), R"(
+        Deselect the nets in the graph view of the GUI.
 
-        :param list[hal_py.net] nets: The nets to be cleared.
+        :param list[hal_py.net] nets: The nets to be deselected.
 )");
 
-py_gui_api.def("clear", py::overload_cast<std::vector<std::shared_ptr<module>>>(&gui_api::clear), py::arg("modules"), R"(
-        Clear the modules in the graph view of the GUI.
+py_gui_api.def("deselect", py::overload_cast<const std::vector<std::shared_ptr<module>>&>(&gui_api::deselect), py::arg("modules"), R"(
+        Deselect the modules in the graph view of the GUI.
 
-        :param list[hal_py.module] modules: The modules to be cleared.
+        :param list[hal_py.module] modules: The modules to be deselected.
 )");
 
-py_gui_api.def("clear", py::overload_cast<std::vector<u32>, std::vector<u32>, std::vector<u32>>(&gui_api::clear), py::arg("gate_ids"), py::arg("net_ids"), py::arg("module_ids"), R"(
-        Clear the gates, nets and modules with the passed ids in the graph view of the GUI.
+py_gui_api.def("deselect", py::overload_cast<const std::vector<u32>&, const std::vector<u32>&, const std::vector<u32>&>(&gui_api::deselect), py::arg("gate_ids"), py::arg("net_ids"), py::arg("module_ids"), R"(
+        Deselect the gates, nets and modules with the passed ids in the graph view of the GUI.
 
-        :param list[hal_py.gate] gates: The ids of the gates to be cleared.
-        :param list[hal_py.net] nets: The ids of the nets to be cleared.
-        :param list[hal_py.module] modules: The ids of the modules to be cleared.
+        :param list[hal_py.gate] gates: The ids of the gates to be deselected.
+        :param list[hal_py.net] nets: The ids of the nets to be deselected.
+        :param list[hal_py.module] modules: The ids of the modules to be deselected.
 )");
 
-py_gui_api.def("clear", py::overload_cast<std::vector<std::shared_ptr<gate>>, std::vector<std::shared_ptr<net>>, std::vector<std::shared_ptr<module>>>(&gui_api::clear), py::arg("gates"), py::arg("nets"), py::arg("modules"), R"(
-        Clear the gates, nets and modules in the graph view of the GUI.
+py_gui_api.def("deselect", py::overload_cast<const std::vector<std::shared_ptr<gate>>&, const std::vector<std::shared_ptr<net>>&, const std::vector<std::shared_ptr<module>>&>(&gui_api::deselect), py::arg("gates"), py::arg("nets"), py::arg("modules"), R"(
+        Deselect the gates, nets and modules in the graph view of the GUI.
 
-        :param list[hal_py.gate] gates: The gates to be cleared.
-        :param list[hal_py.net] nets: The nets to be cleared.
-        :param list[hal_py.module] modules: The modules to be cleared.
+        :param list[hal_py.gate] gates: The gates to be deselected.
+        :param list[hal_py.net] nets: The nets to be deselected.
+        :param list[hal_py.module] modules: The modules to be deselected.
 )");
 
-py_gui_api.def("clear", py::overload_cast<>(&gui_api::clear), R"(
-        Clear all gates, nets and modules in the graph view of the GUI.
+py_gui_api.def("deselect_all_items", py::overload_cast<>(&gui_api::deselect_all_items), R"(
+        Deselect all gates, nets and modules in the graph view of the GUI.
 )");
 
 #ifndef PYBIND11_MODULE


### PR DESCRIPTION
This feature introduces the requested Python GUI API.

The python context now contains an 'gui_api' object by default. It can be accessed via the 'gui' variable.

 The functionality of this feature is centered around

- selecting gates, nets and modules
- clearing the selection of gates, nets and modules
- retrieving the currently selected gates, nets and modules


To retrieve the currently selected gates, nets and modules use the following.
```python
gui.get_selected_gates()
gui.get_selected_nets()
gui.get_selected_modules()
gui.get_selected_items()
```

The last command returns a list containing the gate, net and module list.

If you only want to retrieve the ids use the following.
```python
gui.get_selected_gate_ids()
gui.get_selected_net_ids()
gui.get_selected_module_ids()
gui.get_selected_item_ids()
```

To select gates, nets and modules use the 'select' command. It expects either an object of the type 'gate', 'net' or 'module' or a list of those. It's also possible to pass a list containing three lists. One for each object type or the ids of the objects. The first position in those lists is always 'gates', the second 'nets' and the third 'modules'.

```python
##gate, net, module ids
gate_id_a = 1
gate_id_b = 2

net_id_a = 1
net_id_b = 2

mod_id_a = 1
mod_id_b = 2

##get gate, net, modules by id
gate_a = netlist.get_gate_by_id(gate_id_a)
gate_b = netlist.get_gate_by_id(gate_id_b)

net_a = netlist.get_net_by_id(net_id_a)
net_b = netlist.get_net_by_id(net_id_b)

mod_a = netlist.get_module_by_id(mod_id_a)
mod_b = netlist.get_module_by_id(mod_id_b)

##select gates, nets and modules in different ways
gui.select(gate_a)
gui.select(net_a)
gui.select(mod_a)

gui.select([gate_a, gate_b])
gui.select([net_a, net_b])
gui.select([mod_a, mod_b])

gui.select([gate_a, gate_b],[net_a, net_b],[mod_a, mod_b])

gui.select([gate_id_a, gate_id_b],[net_id_a, net_id_b],[mod_id_a, mod_id_b])
```

On default the current selection gets cleared and the passed objects get selected. If you want to keep your current selection and add to it you have to use the select method with the optional parameter 'clear_current_selection' set to false.

```python
###example to add a gate to current selection
gui.select(gate_a, False)
``` 

Each selection method has a clear counterpart taking the same parameters to remove an item from the current selection.

```python
###example to clear a gate from current selection
gui.clear(gate_a)
``` 