### PR TITLE
Fix multi-driven nets sometimes not being detected as module inputs

### DIFF
--- a/src/netlist/module.cpp
+++ b/src/netlist/module.cpp
@@ -234,12 +234,18 @@ std::set<std::shared_ptr<gate>> module::get_gates(const std::function<bool(const
 
 std::set<std::shared_ptr<net>> module::get_input_nets() const
 {
+    std::unordered_set<u32> seen;
     std::set<std::shared_ptr<net>> res;
     auto gates = get_gates(nullptr, true);
     for (const auto& gate : gates)
     {
         for (const auto& net : gate->get_fan_in_nets())
         {
+            if (seen.find(net->get_id()) != seen.end())
+            {
+                continue;
+            }
+            seen.insert(net->get_id());
             if (m_internal_manager->m_netlist->is_global_input_net(net))
             {
                 res.insert(net);
@@ -257,12 +263,18 @@ std::set<std::shared_ptr<net>> module::get_input_nets() const
 
 std::set<std::shared_ptr<net>> module::get_output_nets() const
 {
+    std::unordered_set<u32> seen;
     std::set<std::shared_ptr<net>> res;
     auto gates = get_gates(nullptr, true);
     for (const auto& gate : gates)
     {
         for (const auto& net : gate->get_fan_out_nets())
         {
+            if (seen.find(net->get_id()) != seen.end())
+            {
+                continue;
+            }
+            seen.insert(net->get_id());
             if (m_internal_manager->m_netlist->is_global_output_net(net))
             {
                 res.insert(net);
@@ -280,12 +292,18 @@ std::set<std::shared_ptr<net>> module::get_output_nets() const
 
 std::set<std::shared_ptr<net>> module::get_internal_nets() const
 {
+    std::unordered_set<u32> seen;
     std::set<std::shared_ptr<net>> res;
     auto gates = get_gates(nullptr, true);
     for (const auto& gate : gates)
     {
         for (const auto& net : gate->get_fan_out_nets())
         {
+            if (seen.find(net->get_id()) != seen.end())
+            {
+                continue;
+            }
+            seen.insert(net->get_id());
             auto destinations = net->get_destinations();
             if (std::any_of(destinations.begin(), destinations.end(), [gates](endpoint dst){return gates.find(dst.get_gate()) != gates.end();}))
             {

--- a/src/netlist/module.cpp
+++ b/src/netlist/module.cpp
@@ -252,7 +252,7 @@ std::set<std::shared_ptr<net>> module::get_input_nets() const
                 continue;
             }
             auto sources = net->get_sources();
-            if (std::any_of(sources.begin(), sources.end(), [gates](endpoint src){return gates.find(src.get_gate()) == gates.end();}))
+            if (std::any_of(sources.begin(), sources.end(), [&gates](endpoint src){return gates.find(src.get_gate()) == gates.end();}))
             {
                 res.insert(net);
             }
@@ -281,7 +281,7 @@ std::set<std::shared_ptr<net>> module::get_output_nets() const
                 continue;
             }
             auto destinations = net->get_destinations();
-            if (std::any_of(destinations.begin(), destinations.end(), [gates](endpoint dst){return gates.find(dst.get_gate()) == gates.end();}))
+            if (std::any_of(destinations.begin(), destinations.end(), [&gates](endpoint dst){return gates.find(dst.get_gate()) == gates.end();}))
             {
                 res.insert(net);
             }
@@ -305,7 +305,7 @@ std::set<std::shared_ptr<net>> module::get_internal_nets() const
             }
             seen.insert(net->get_id());
             auto destinations = net->get_destinations();
-            if (std::any_of(destinations.begin(), destinations.end(), [gates](endpoint dst){return gates.find(dst.get_gate()) != gates.end();}))
+            if (std::any_of(destinations.begin(), destinations.end(), [&gates](endpoint dst){return gates.find(dst.get_gate()) != gates.end();}))
             {
                 res.insert(net);
             }

--- a/src/netlist/module.cpp
+++ b/src/netlist/module.cpp
@@ -245,15 +245,10 @@ std::set<std::shared_ptr<net>> module::get_input_nets() const
                 res.insert(net);
                 continue;
             }
-            for (const auto& src : net->get_sources())
+            auto sources = net->get_sources();
+            if (std::any_of(sources.begin(), sources.end(), [gates](endpoint src){return gates.find(src.get_gate()) == gates.end();}))
             {
-                // mark as input net if at least one source is not within the
-                // module
-                if (gates.find(src.get_gate()) == gates.end())
-                {
-                    res.insert(net);
-                    break;
-                }
+                res.insert(net);
             }
         }
     }
@@ -273,15 +268,10 @@ std::set<std::shared_ptr<net>> module::get_output_nets() const
                 res.insert(net);
                 continue;
             }
-            for (const auto& dst : net->get_destinations())
+            auto destinations = net->get_destinations();
+            if (std::any_of(destinations.begin(), destinations.end(), [gates](endpoint dst){return gates.find(dst.get_gate()) == gates.end();}))
             {
-                // mark as output net if at least one destination is not
-                // within the module
-                if (gates.find(dst.get_gate()) == gates.end())
-                {
-                    res.insert(net);
-                    break;
-                }
+                res.insert(net);
             }
         }
     }
@@ -296,13 +286,10 @@ std::set<std::shared_ptr<net>> module::get_internal_nets() const
     {
         for (const auto& net : gate->get_fan_out_nets())
         {
-            for (const auto& dst : net->get_destinations())
+            auto destinations = net->get_destinations();
+            if (std::any_of(destinations.begin(), destinations.end(), [gates](endpoint dst){return gates.find(dst.get_gate()) != gates.end();}))
             {
-                if (gates.find(dst.get_gate()) != gates.end())
-                {
-                    res.insert(net);
-                    break;
-                }
+                res.insert(net);
             }
         }
     }


### PR DESCRIPTION
This makes modules' input net detection mechanism compatible with multi-driven nets and removes the reference to the deprecated `get_source()` method.