### PR TITLE
Make everything in the GUI but the graph widget compatible with multi-driven nets

### DIFF
--- a/include/gui/graph_widget/graph_navigation_widget.h
+++ b/include/gui/graph_widget/graph_navigation_widget.h
@@ -18,8 +18,9 @@ class graph_navigation_widget : public QTableWidget
 public:
     explicit graph_navigation_widget(QWidget *parent = nullptr);
 
-    void setup();
-    void setup(hal::node origin, std::shared_ptr<net> via_net);
+    // right = true
+    void setup(bool direction);
+    void setup(hal::node origin, std::shared_ptr<net> via_net, bool direction);
     void hide_when_focus_lost(bool hide);
     void focusOutEvent(QFocusEvent *event) override;
 
@@ -32,7 +33,7 @@ protected:
     void keyPressEvent(QKeyEvent* event) Q_DECL_OVERRIDE;
 
 private:
-    void fill_table(std::shared_ptr<net> n);
+    void fill_table(std::shared_ptr<net> n, bool direction);
     void handle_item_double_clicked(QTableWidgetItem* item);
     void commit_selection();
     graph_graphics_view* m_view;

--- a/include/gui/selection_details_widget/gate_details_widget.h
+++ b/include/gui/selection_details_widget/gate_details_widget.h
@@ -79,7 +79,8 @@ public Q_SLOTS:
     void handle_module_gate_removed(std::shared_ptr<module> module, u32 associated_data);
 
     void handle_net_name_changed(std::shared_ptr<net> net);
-    void handle_net_source_changed(std::shared_ptr<net> net);
+    void handle_net_source_added(std::shared_ptr<net> net, const u32 src_gate_id);
+    void handle_net_source_removed(std::shared_ptr<net> net, const u32 src_gate_id);
     void handle_net_destination_added(std::shared_ptr<net> net, const u32 dst_gate_id);
     void handle_net_destination_removed(std::shared_ptr<net> net, const u32 dst_gate_id);
 

--- a/include/gui/selection_details_widget/module_details_widget.h
+++ b/include/gui/selection_details_widget/module_details_widget.h
@@ -63,7 +63,8 @@ public Q_SLOTS:
 
     void handle_net_removed(const std::shared_ptr<net> n);
     void handle_net_name_changed(const std::shared_ptr<net> n);
-    void handle_net_source_changed(const std::shared_ptr<net> n);
+    void handle_net_source_added(const std::shared_ptr<net> n, const u32 src_gate_id);
+    void handle_net_source_removed(const std::shared_ptr<net> n, const u32 src_gate_id);
     void handle_net_destination_added(const std::shared_ptr<net> n, const u32 dst_gate_id);
     void handle_net_destination_removed(const std::shared_ptr<net> n, const u32 dst_gate_id);
 

--- a/include/gui/selection_details_widget/net_details_widget.h
+++ b/include/gui/selection_details_widget/net_details_widget.h
@@ -59,7 +59,8 @@ public Q_SLOTS:
 
     void handle_net_removed(const std::shared_ptr<net> n);
     void handle_net_name_changed(const std::shared_ptr<net> n);
-    void handle_net_source_changed(const std::shared_ptr<net> n);
+    void handle_net_source_added(const std::shared_ptr<net> n, const u32 src_gate_id);
+    void handle_net_source_removed(const std::shared_ptr<net> n, const u32 src_gate_id);
     void handle_net_destination_added(const std::shared_ptr<net> n, const u32 dst_gate_id);
     void handle_net_destination_removed(const std::shared_ptr<net> n, const u32 dst_gate_id);
 

--- a/src/gui/graph_widget/contexts/graph_context.cpp
+++ b/src/gui/graph_widget/contexts/graph_context.cpp
@@ -246,12 +246,15 @@ bool graph_context::is_showing_module(const u32 id, const QSet<u32>& minus_modul
 bool graph_context::is_showing_net_source(const u32 net_id) const
 {
     auto net = g_netlist->get_net_by_id(net_id);
-    auto src_gate = net->get_source().get_gate();
+    auto src_pins = net->get_sources();
 
-    if(src_gate != nullptr)
+    for(auto pin : src_pins)
     {
-        if(m_gates.contains(src_gate->get_id()))
-            return true;
+        if(pin.get_gate() != nullptr)
+        {
+            if(m_gates.contains(pin.get_gate()->get_id()))
+                return true;
+        }
     }
 
     return false;

--- a/src/gui/graph_widget/graph_context_manager.cpp
+++ b/src/gui/graph_widget/graph_context_manager.cpp
@@ -164,9 +164,9 @@ void graph_context_manager::handle_net_source_added(const std::shared_ptr<net> n
 {
     for(graph_context* context : m_graph_contexts)
     {
-        // FIXME
-        // if(context->nets().contains(n->get_id()) || (context->is_showing_net_source(n->get_id()) && (n->is_global_output_net() || context->is_showing_net_destination(n->get_id()))))
+        if(context->nets().contains(n->get_id()) || context->gates().contains(src_gate_id))
         {
+            // forcibly apply changes since nets need to be recalculated
             context->apply_changes();
             context->schedule_scene_update();
         }
@@ -177,9 +177,9 @@ void graph_context_manager::handle_net_source_removed(const std::shared_ptr<net>
 {
     for(graph_context* context : m_graph_contexts)
     {
-        // FIXME
-        // if(context->nets().contains(n->get_id()) || (context->is_showing_net_source(n->get_id()) && (n->is_global_output_net() || context->is_showing_net_destination(n->get_id()))))
+        if(context->nets().contains(n->get_id()))
         {
+            // forcibly apply changes since nets need to be recalculated
             context->apply_changes();
             context->schedule_scene_update();
         }
@@ -188,11 +188,11 @@ void graph_context_manager::handle_net_source_removed(const std::shared_ptr<net>
 
 void graph_context_manager::handle_net_destination_added(const std::shared_ptr<net> n, const u32 dst_gate_id) const
 {
-    Q_UNUSED(dst_gate_id);
     for(graph_context* context : m_graph_contexts)
     {
-        if(context->nets().contains(n->get_id()) || (context->is_showing_net_destination(n->get_id()) && (n->is_global_input_net() || context->is_showing_net_source(n->get_id()))))
+        if(context->nets().contains(n->get_id()) || context->gates().contains(dst_gate_id))
         {
+            // forcibly apply changes since nets need to be recalculated
             context->apply_changes();
             context->schedule_scene_update();
         }
@@ -201,11 +201,15 @@ void graph_context_manager::handle_net_destination_added(const std::shared_ptr<n
 
 void graph_context_manager::handle_net_destination_removed(const std::shared_ptr<net> n, const u32 dst_gate_id) const
 {
-    Q_UNUSED(dst_gate_id)
-
     for (graph_context* context : m_graph_contexts)
+    {
         if (context->nets().contains(n->get_id()))
+        {
+            // forcibly apply changes since nets need to be recalculated
+            context->apply_changes();
             context->schedule_scene_update();
+        }
+    }
 }
 
 void graph_context_manager::handle_marked_global_input(u32 net_id)

--- a/src/gui/graph_widget/graph_navigation_widget.cpp
+++ b/src/gui/graph_widget/graph_navigation_widget.cpp
@@ -30,8 +30,8 @@ graph_navigation_widget::graph_navigation_widget(QWidget* parent) : QTableWidget
     //    setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 }
 
-void graph_navigation_widget::setup()
-{
+void graph_navigation_widget::setup(bool direction)
+{ 
     clearContents();
 
     switch (g_selection_relay.m_focus_type)
@@ -51,15 +51,15 @@ void graph_navigation_widget::setup()
 
             m_origin = hal::node{hal::node_type::gate, g->get_id()};
 
-            std::string pin_type   = g->get_output_pins()[g_selection_relay.m_subfocus_index];
-            std::shared_ptr<net> n = g->get_fan_out_net(pin_type);
+            std::string pin_type   = (direction ? g->get_output_pins() : g->get_input_pins())[g_selection_relay.m_subfocus_index];
+            std::shared_ptr<net> n = (direction ? g->get_fan_out_net(pin_type) : g->get_fan_in_net(pin_type));
 
             if (!n)
             {
                 return;
             }
 
-            fill_table(n);
+            fill_table(n, direction);
 
             return;
         }
@@ -81,7 +81,7 @@ void graph_navigation_widget::setup()
                 return;
             }
 
-            fill_table(n);
+            fill_table(n, direction);
 
             return;
         }
@@ -93,10 +93,10 @@ void graph_navigation_widget::setup()
     }
 }
 
-void graph_navigation_widget::setup(hal::node origin, std::shared_ptr<net> via_net)
+void graph_navigation_widget::setup(hal::node origin, std::shared_ptr<net> via_net, bool direction)
 {
     clearContents();
-    fill_table(via_net);
+    fill_table(via_net, direction);
     m_origin = origin;
 }
 
@@ -131,7 +131,7 @@ void graph_navigation_widget::keyPressEvent(QKeyEvent* event)
     }
 }
 
-void graph_navigation_widget::fill_table(std::shared_ptr<net> n)
+void graph_navigation_widget::fill_table(std::shared_ptr<net> n, bool direction)
 {
     if (!n)
     {
@@ -158,7 +158,7 @@ void graph_navigation_widget::fill_table(std::shared_ptr<net> n)
 
     int row = 1;
 
-    for (const endpoint& e : n->get_destinations())
+    for (const endpoint& e : (direction ? n->get_destinations() : n->get_sources()))
     {
         if (!e.get_gate())
         {

--- a/src/gui/graph_widget/graph_navigation_widget.cpp
+++ b/src/gui/graph_widget/graph_navigation_widget.cpp
@@ -10,6 +10,8 @@
 #include <QKeyEvent>
 #include <QScrollBar>
 
+#include <assert.h>
+
 graph_navigation_widget::graph_navigation_widget(QWidget* parent) : QTableWidget(parent), m_via_net(0)
 {
     m_hide_when_focus_lost = false;
@@ -44,20 +46,14 @@ void graph_navigation_widget::setup(bool direction)
         {
             std::shared_ptr<gate> g = g_netlist->get_gate_by_id(g_selection_relay.m_focus_id);
 
-            if (!g)
-            {
-                return;
-            }
+            assert(g);
 
             m_origin = hal::node{hal::node_type::gate, g->get_id()};
 
             std::string pin_type   = (direction ? g->get_output_pins() : g->get_input_pins())[g_selection_relay.m_subfocus_index];
             std::shared_ptr<net> n = (direction ? g->get_fan_out_net(pin_type) : g->get_fan_in_net(pin_type));
 
-            if (!n)
-            {
-                return;
-            }
+            assert(n);
 
             fill_table(n, direction);
 
@@ -67,20 +63,11 @@ void graph_navigation_widget::setup(bool direction)
         {
             std::shared_ptr<net> n = g_netlist->get_net_by_id(g_selection_relay.m_focus_id);
 
-            if (!n)
-            {
-                return;
-            }
+            assert(n);
+            assert(n->get_num_of_sources());
 
             m_origin = hal::node{hal::node_type::gate, 0};
-
-            std::shared_ptr<gate> g = n->get_source().get_gate();
-
-            if (!g)
-            {
-                return;
-            }
-
+            
             fill_table(n, direction);
 
             return;
@@ -133,10 +120,7 @@ void graph_navigation_widget::keyPressEvent(QKeyEvent* event)
 
 void graph_navigation_widget::fill_table(std::shared_ptr<net> n, bool direction)
 {
-    if (!n)
-    {
-        return;
-    }
+    assert(n);
 
     m_via_net = n->get_id();
 

--- a/src/gui/graph_widget/graph_widget.cpp
+++ b/src/gui/graph_widget/graph_widget.cpp
@@ -308,7 +308,7 @@ void graph_widget::handle_navigation_left_request()
                 if (!n)
                     return;
 
-                if (n->get_source().get_gate() == nullptr)
+                if (n->get_num_of_sources() == 0)
                 {
                     g_selection_relay.clear();
                     g_selection_relay.m_selected_nets.insert(n->get_id());
@@ -316,9 +316,15 @@ void graph_widget::handle_navigation_left_request()
                     g_selection_relay.m_focus_id   = n->get_id();
                     g_selection_relay.relay_selection_changed(nullptr);
                 }
-                else
+                else if (n->get_num_of_sources() == 1)
                 {
                     handle_navigation_jump_requested(hal::node{hal::node_type::gate, g->get_id()}, n->get_id(), {n->get_source().get_gate()->get_id()});
+                }
+                else
+                {
+                    m_navigation_widget->setup(false);
+                    m_navigation_widget->setFocus();
+                    m_overlay->show();
                 }
             }
             else if (g->get_input_pins().size())
@@ -338,9 +344,18 @@ void graph_widget::handle_navigation_left_request()
             if (!n)
                 return;
 
-            if (n->get_source().get_gate() != nullptr)
+            if (n->get_num_of_sources() == 0)
+                return;
+
+            if (n->get_num_of_sources() == 1)
             {
-                handle_navigation_jump_requested(hal::node{hal::node_type::gate, 0}, n->get_id(), {n->get_source().get_gate()->get_id()});
+                handle_navigation_jump_requested(hal::node{hal::node_type::gate, 0}, n->get_id(), {n->get_sources()[0].get_gate()->get_id()});
+            }
+            else
+            {
+                m_navigation_widget->setup(false);
+                m_navigation_widget->setFocus();
+                m_overlay->show();
             }
 
             return;
@@ -384,7 +399,7 @@ void graph_widget::handle_navigation_right_request()
                 }
                 else
                 {
-                    m_navigation_widget->setup();
+                    m_navigation_widget->setup(true);
                     m_navigation_widget->setFocus();
                     m_overlay->show();
                 }
@@ -415,7 +430,7 @@ void graph_widget::handle_navigation_right_request()
             }
             else
             {
-                m_navigation_widget->setup();
+                m_navigation_widget->setup(true);
                 m_navigation_widget->setFocus();
                 m_overlay->show();
             }

--- a/src/gui/selection_details_widget/gate_details_widget.cpp
+++ b/src/gui/selection_details_widget/gate_details_widget.cpp
@@ -211,11 +211,17 @@ void gate_details_widget::handle_net_name_changed(std::shared_ptr<net> net)
 {
     bool update_needed = false;
 
-    //check if currently shown gate is src of renamed net
-    if (m_current_id == net->get_source().get_gate()->get_id())
-        update_needed = true;
+    //check if currently shown gate is a src of renamed net
+    for (auto& e : net->get_sources())
+    {
+        if (m_current_id == e.get_gate()->get_id())
+        {
+            update_needed = true;
+            break;
+        }
+    }
 
-    //check if currently shown gate is dst of renamed net
+    //check if currently shown gate is a dst of renamed net
     if (!update_needed)
     {
         for (auto& e : net->get_destinations())

--- a/src/gui/selection_details_widget/gate_details_widget.cpp
+++ b/src/gui/selection_details_widget/gate_details_widget.cpp
@@ -176,8 +176,8 @@ gate_details_widget::gate_details_widget(QWidget* parent) : QWidget(parent)
 
     //handle netlist modifications reagarding nets
     connect(&g_netlist_relay, &netlist_relay::net_name_changed, this, &gate_details_widget::handle_net_name_changed);
-    // FIXME change to source_added, source_removed
-    // connect(&g_netlist_relay, &netlist_relay::net_source_changed, this, &gate_details_widget::handle_net_source_changed);
+    connect(&g_netlist_relay, &netlist_relay::net_source_added, this, &gate_details_widget::handle_net_source_added);
+    connect(&g_netlist_relay, &netlist_relay::net_source_removed, this, &gate_details_widget::handle_net_source_removed);
     connect(&g_netlist_relay, &netlist_relay::net_destination_added, this, &gate_details_widget::handle_net_destination_added);
     connect(&g_netlist_relay, &netlist_relay::net_destination_removed, this, &gate_details_widget::handle_net_destination_removed);
 }
@@ -232,15 +232,19 @@ void gate_details_widget::handle_net_name_changed(std::shared_ptr<net> net)
         update(m_current_id);
 }
 
-// FIXME change to source_added, source_removed
-// void gate_details_widget::handle_net_source_changed(std::shared_ptr<net> net)
-// {
-//     Q_UNUSED(net);
-//     if (m_current_id == 0)
-//         return;
-//     if (g_netlist->is_gate_in_netlist(g_netlist->get_gate_by_id(m_current_id)))
-//         update(m_current_id);
-// }
+void gate_details_widget::handle_net_source_added(std::shared_ptr<net> net, const u32 src_gate_id)
+{
+    Q_UNUSED(net);
+    if (m_current_id == src_gate_id)
+        update(m_current_id);
+}
+
+void gate_details_widget::handle_net_source_removed(std::shared_ptr<net> net, const u32 src_gate_id)
+{
+    Q_UNUSED(net);
+    if (m_current_id == src_gate_id)
+        update(m_current_id);
+}
 
 void gate_details_widget::handle_net_destination_added(std::shared_ptr<net> net, const u32 dst_gate_id)
 {

--- a/src/gui/selection_details_widget/module_details_widget.cpp
+++ b/src/gui/selection_details_widget/module_details_widget.cpp
@@ -98,8 +98,8 @@ module_details_widget::module_details_widget(QWidget* parent)
 
     connect(&g_netlist_relay, &netlist_relay::net_removed, this, &module_details_widget::handle_net_removed);
     connect(&g_netlist_relay, &netlist_relay::net_name_changed, this, &module_details_widget::handle_net_name_changed);
-    // FIXME change to source_added, source_removed
-    // connect(&g_netlist_relay, &netlist_relay::net_source_changed, this, &module_details_widget::handle_net_source_changed);
+    connect(&g_netlist_relay, &netlist_relay::net_source_added, this, &module_details_widget::handle_net_source_added);
+    connect(&g_netlist_relay, &netlist_relay::net_source_removed, this, &module_details_widget::handle_net_source_removed);
     connect(&g_netlist_relay, &netlist_relay::net_destination_added, this, &module_details_widget::handle_net_destination_added);
     connect(&g_netlist_relay, &netlist_relay::net_destination_removed, this, &module_details_widget::handle_net_destination_removed);
 
@@ -205,23 +205,38 @@ void module_details_widget::handle_net_name_changed(const std::shared_ptr<net> n
     if (!mod)
         return;
 
-    if (mod->get_input_nets().find(n) != mod->get_input_nets().end() || mod->get_internal_nets().find(n) != mod->get_internal_nets().end()
-        || mod->get_output_nets().find(n) != mod->get_output_nets().end())
+    if (mod->get_internal_nets().find(n) != mod->get_internal_nets().end())
         update(m_current_id);
 }
 
-// FIXME change to source_added, source_removed
-// void module_details_widget::handle_net_source_changed(const std::shared_ptr<net> n)
-// {
-//     Q_UNUSED(n);
-//     update(m_current_id);
-// }
+void module_details_widget::handle_net_source_added(const std::shared_ptr<net> n, const u32 src_gate_id)
+{
+    Q_UNUSED(n);
+    if (m_current_id == 0)
+        return;
+    auto g = g_netlist->get_gate_by_id(src_gate_id);
+    if (g_netlist->get_module_by_id(m_current_id)->contains_gate(g))
+        update(m_current_id);
+}
+
+void module_details_widget::handle_net_source_removed(const std::shared_ptr<net> n, const u32 src_gate_id)
+{
+    Q_UNUSED(n);
+    if (m_current_id == 0)
+        return;
+    auto g = g_netlist->get_gate_by_id(src_gate_id);
+    if (g_netlist->get_module_by_id(m_current_id)->contains_gate(g))
+        update(m_current_id);
+}
 
 void module_details_widget::handle_net_destination_added(const std::shared_ptr<net> n, const u32 dst_gate_id)
 {
-    Q_UNUSED(dst_gate_id);
-    //would have written the same logic in this funtion, so just use the function below
-    handle_net_name_changed(n);
+    Q_UNUSED(n);
+    if (m_current_id == 0)
+        return;
+    auto g = g_netlist->get_gate_by_id(dst_gate_id);
+    if (g_netlist->get_module_by_id(m_current_id)->contains_gate(g))
+        update(m_current_id);
 }
 
 void module_details_widget::handle_net_destination_removed(const std::shared_ptr<net> n, const u32 dst_gate_id)

--- a/src/gui/selection_details_widget/net_details_widget.cpp
+++ b/src/gui/selection_details_widget/net_details_widget.cpp
@@ -376,9 +376,15 @@ void net_details_widget::handle_gate_name_changed(const std::shared_ptr<gate> g)
     if(!g_netlist->is_net_in_netlist(n))
         return;
 
-    //check if renamed gate is src of the currently shown net
-    if(n->get_source().get_gate()->get_id() == m_current_id)
-        update_needed = true;
+    //check if renamed gate is a src of the currently shown net
+    for(auto e : n->get_sources())
+    {
+        if(e.get_gate()->get_id() == m_current_id)
+        {
+            update_needed = true;
+            break;
+        }
+    }
 
     //check if renamed gate is a dst of the currently shown net
     if(!update_needed)

--- a/src/gui/selection_details_widget/net_details_widget.cpp
+++ b/src/gui/selection_details_widget/net_details_widget.cpp
@@ -139,8 +139,8 @@ net_details_widget::net_details_widget(QWidget* parent) : QWidget(parent)
 
     connect(&g_netlist_relay, &netlist_relay::net_removed, this, &net_details_widget::handle_net_removed);
     connect(&g_netlist_relay, &netlist_relay::net_name_changed, this, &net_details_widget::handle_net_name_changed);
-    // FIXME change to source_added, source_removed
-    // connect(&g_netlist_relay, &netlist_relay::net_source_changed, this, &net_details_widget::handle_net_source_changed);
+    connect(&g_netlist_relay, &netlist_relay::net_source_added, this, &net_details_widget::handle_net_source_added);
+    connect(&g_netlist_relay, &netlist_relay::net_source_removed, this, &net_details_widget::handle_net_source_removed);
     connect(&g_netlist_relay, &netlist_relay::net_destination_added, this, &net_details_widget::handle_net_destination_added);
     connect(&g_netlist_relay, &netlist_relay::net_destination_removed, this, &net_details_widget::handle_net_destination_removed);
 
@@ -188,20 +188,28 @@ void net_details_widget::update(u32 net_id)
     QString module_text = "";
     m_module_item->setText(module_text);
 
-    //get src pin
+    //update source pins
     for (auto item : m_source_pin->takeChildren())
         delete item;
 
-    auto src_pin = n->get_source();
+    m_source_pin->setText(0, "");
 
-    if (src_pin.get_gate() != nullptr)
+    if (!g_netlist->is_global_input_net(n))
     {
-        auto src_pin_type = src_pin.get_pin();
+        auto src_pins = n->get_sources();
 
-        if (!src_pin_type.empty())
+        QString src_text = QString::number(src_pins.size()) + " Source Pins";
+
+        if (src_pins.size() == 1)
+            src_text.chop(1);
+
+        m_source_pin->setText(0, src_text);
+
+        for (auto src_pin : src_pins)
         {
+            auto src_pin_type = src_pin.get_pin();
+
             QTreeWidgetItem* item = new QTreeWidgetItem(m_source_pin);
-            m_source_pin->setText(0, "1 Source Pin");
             item->setText(0, QString::fromStdString(src_pin_type));
             item->setText(1, QChar(0x2b05));
             item->setForeground(1, QBrush(QColor(114, 140, 0), Qt::SolidPattern));
@@ -209,12 +217,8 @@ void net_details_widget::update(u32 net_id)
             item->setData(2, Qt::UserRole, src_pin.get_gate()->get_id());
         }
     }
-    else
-    {
-        m_source_pin->setText(0, "No Source Pin");
-    }
 
-    //get destination pins
+    //update destination pins
     for (auto item : m_destination_pins->takeChildren())
         delete item;
 
@@ -324,12 +328,21 @@ void net_details_widget::handle_net_name_changed(const std::shared_ptr<net> n)
 
 }
 
-// FIXME change to source_added, source_removed
-// void net_details_widget::handle_net_source_changed(const std::shared_ptr<net> n)
-// {
-//     if(m_current_id == n->get_id())
-//         update(m_current_id);
-// }
+void net_details_widget::handle_net_source_added(const std::shared_ptr<net> n, const u32 src_gate_id)
+{
+    Q_UNUSED(src_gate_id);
+
+    if(m_current_id == n->get_id())
+        update(m_current_id);
+}
+
+void net_details_widget::handle_net_source_removed(const std::shared_ptr<net> n, const u32 src_gate_id)
+{
+    Q_UNUSED(src_gate_id);
+
+    if(m_current_id == n->get_id())
+        update(m_current_id);
+}
 
 void net_details_widget::handle_net_destination_added(const std::shared_ptr<net> n, const u32 dst_gate_id)
 {


### PR DESCRIPTION
Hi @Slowpoke42,

here are some fixes for pretty much everything but the graph widget itself regarding support for multi-driven nets. This removes (most of) the references to `net::get_source()` and adds support for navigation to the left in a multi-driven scenario. Also, a lot of event handlers have been updated to support the new API. You can merge this into your branch if you like.