### PR TITLE
De-clutter the settings page

### DIFF
--- a/include/gui/settings/settings_widget.h
+++ b/include/gui/settings/settings_widget.h
@@ -61,8 +61,6 @@ namespace hal
         void reset_labels();
         bool match_labels(const QString& string);
 
-        void trigger_setting_updated();
-        void set_dirty(bool dirty);
         bool dirty() const;
         void prepare(const QVariant& value, const QVariant& default_value);
         void mark_saved();
@@ -83,6 +81,11 @@ namespace hal
         void setting_updated(SettingsWidget* sender, const QString& key, const QVariant& value);
 
     protected:
+        void set_dirty(bool dirty);
+        void trigger_setting_updated();
+        void enterEvent(QEvent* event);
+        void leaveEvent(QEvent* event);
+
         QVBoxLayout* m_layout;
         QBoxLayout* m_container;
         QHBoxLayout* m_top_bar;

--- a/resources/stylesheet/darcula.qss
+++ b/resources/stylesheet/darcula.qss
@@ -416,6 +416,14 @@ hal--SettingsWidget #name-label {
     font       : 14px bold "Iosevka";
 }
 
+hal--SettingsWidget QToolButton {
+    color : #D3DCE6;
+}
+
+hal--SettingsWidget QToolButton:disabled {
+    color : #888888;
+}
+
 /* LABEL_BUTTON */
 
 hal--SettingsWidget hal--label_button {

--- a/resources/stylesheet/sunny.qss
+++ b/resources/stylesheet/sunny.qss
@@ -432,6 +432,14 @@ SettingsWidget #name-label {
     font       : 14px bold "Iosevka";
 }
 
+hal--SettingsWidget QToolButton {
+    color : #000;
+}
+
+hal--SettingsWidget QToolButton:disabled {
+    color : #808080;
+}
+
 /* LABEL_BUTTON */
 
 SettingsWidget label_button {


### PR DESCRIPTION
Keep all settings widgets the same width. Also, only show the undo/revert buttons for the widget that has the mouse over it.