### PR TITLE
Build dependencies for Arch Linux added

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -53,9 +53,15 @@ if [[ "$platform" == 'macOS' ]]; then
 elif [[ "$platform" == 'linux' ]]; then
     if [[ "$distribution" == 'Ubuntu' ]]; then
         sudo apt-get update && sudo apt-get install -y build-essential lsb-release git cmake pkgconf libboost-all-dev qt5-default \
-        libpython3-dev build-essential ccache autoconf autotools-dev libsodium-dev libigraph0-dev \
+        libpython3-dev ccache autoconf autotools-dev libsodium-dev libigraph0-dev \
         libqt5svg5-dev libqt5svg5* ninja-build lcov gcovr python3-sphinx doxygen python3-sphinx-rtd-theme python3-jedi python3-pip pybind11-dev python3-pybind11 rapidjson-dev libspdlog-dev \
         graphviz # For documentation
+        sudo pip3 install -r requirements.txt
+    elif [[ "$distribution" == "Arch" ]]; then
+        yay -S --needed base-devel lsb-release git cmake pkgconf boost-libs \
+        qt5-base python ccache autoconf libsodium igraph qt5-svg ninja lcov \
+        gcovr python-sphinx doxygen python-sphinx_rtd_theme python-jedi \
+        python-pip pybind11 rapidjson spdlog graphviz
         sudo pip3 install -r requirements.txt
     else
        echo "Unsupported Linux distribution: abort!"


### PR DESCRIPTION
I simply translated the APT build dependencies over to be compatible with yay / pacman package systems from Arch Linux. Afterwards I was able to build HAL.

Additionally, there is one dependency duplicate in the Ubuntu list (build-essential) which I removed in this procedure.