### PR TITLE
removed gtest_main from test targets

### DIFF
--- a/plugins/hgl_parser/test/CMakeLists.txt
+++ b/plugins/hgl_parser/test/CMakeLists.txt
@@ -6,7 +6,7 @@ if(BUILD_TESTS)
 
     add_executable(runTest-hgl_parser  hgl_parser.cpp)
 
-    target_link_libraries(runTest-hgl_parser   hgl_parser pthread gtest gtest_main hal::core hal::netlist test_utils)
+    target_link_libraries(runTest-hgl_parser   hgl_parser pthread gtest hal::core hal::netlist test_utils)
 
     add_test(runTest-hgl_parser ${CMAKE_BINARY_DIR}/bin/hal_plugins/runTest-hgl_parser --gtest_output=xml:${CMAKE_BINARY_DIR}/gtestresults-runBasicTests.xml)
 

--- a/plugins/hgl_writer/test/CMakeLists.txt
+++ b/plugins/hgl_writer/test/CMakeLists.txt
@@ -5,7 +5,7 @@ if(BUILD_TESTS)
 
     add_executable(runTest-hgl_writer  hgl_writer.cpp)
 
-    target_link_libraries(runTest-hgl_writer hgl_writer hgl_parser pthread gtest gtest_main hal::core hal::netlist test_utils)
+    target_link_libraries(runTest-hgl_writer hgl_writer hgl_parser pthread gtest hal::core hal::netlist test_utils)
 
     add_test(runTest-hgl_writer ${CMAKE_BINARY_DIR}/bin/hal_plugins/runTest-hgl_writer --gtest_output=xml:${CMAKE_BINARY_DIR}/gtestresults-runBasicTests.xml)
 

--- a/plugins/liberty_parser/test/CMakeLists.txt
+++ b/plugins/liberty_parser/test/CMakeLists.txt
@@ -23,7 +23,7 @@ if(BUILD_TESTS)
 
     add_executable(runTest-liberty_parser  liberty_parser.cpp)
 
-    target_link_libraries(runTest-liberty_parser   liberty_parser pthread gtest gtest_main hal::core hal::netlist test_utils)
+    target_link_libraries(runTest-liberty_parser   liberty_parser pthread gtest hal::core hal::netlist test_utils)
 
     add_test(runTest-liberty_parser ${CMAKE_BINARY_DIR}/bin/hal_plugins/runTest-liberty_parser --gtest_output=xml:${CMAKE_BINARY_DIR}/gtestresults-runBasicTests.xml)
 

--- a/plugins/netlist_simulator/test/CMakeLists.txt
+++ b/plugins/netlist_simulator/test/CMakeLists.txt
@@ -43,7 +43,7 @@ if(BUILD_TESTS)
 
     add_executable(runTest-netlist_simulator simulator_test.cpp)
 
-    target_link_libraries(runTest-netlist_simulator netlist_simulator test_utils gtest gtest_main ${LINK_LIBS})
+    target_link_libraries(runTest-netlist_simulator netlist_simulator test_utils gtest ${LINK_LIBS})
 
     add_test(runTest-netlist_simulator ${CMAKE_BINARY_DIR}/bin/hal_plugins/runTest-netlist_simulator --gtest_output=xml:${CMAKE_BINARY_DIR}/gtestresults-runTest-netlist_simulator.xml)
 

--- a/plugins/vhdl_verilog_writers/test/CMakeLists.txt
+++ b/plugins/vhdl_verilog_writers/test/CMakeLists.txt
@@ -11,8 +11,8 @@ if(BUILD_TESTS AND (PL_VHDL_VERILOG_PARSERS OR BUILD_ALL_PLUGINS))
     add_executable(runTest-hdl_writer_verilog  hdl_writer_verilog.cpp)
     add_executable(runTest-hdl_writer_vhdl  hdl_writer_vhdl.cpp)
 
-    target_link_libraries(runTest-hdl_writer_verilog   vhdl_verilog_writers vhdl_verilog_parsers pthread gtest gtest_main hal::core hal::netlist test_utils)
-    target_link_libraries(runTest-hdl_writer_vhdl  vhdl_verilog_writers vhdl_verilog_parsers pthread gtest gtest_main hal::core hal::netlist test_utils)
+    target_link_libraries(runTest-hdl_writer_verilog   vhdl_verilog_writers vhdl_verilog_parsers pthread gtest hal::core hal::netlist test_utils)
+    target_link_libraries(runTest-hdl_writer_vhdl  vhdl_verilog_writers vhdl_verilog_parsers pthread gtest hal::core hal::netlist test_utils)
 
     add_test(runTest-hdl_writer_verilog ${CMAKE_BINARY_DIR}/bin/hal_plugins/runTest-hdl_writer_verilog --gtest_output=xml:${CMAKE_BINARY_DIR}/gtestresults-runBasicTests.xml)
     add_test(runTest-hdl_writer_vhdl ${CMAKE_BINARY_DIR}/bin/hal_plugins/runTest-hdl_writer_vhdl --gtest_output=xml:${CMAKE_BINARY_DIR}/gtestresults-runBasicTests.xml)


### PR DESCRIPTION
Fixes the issue that multiple main functions were linked in some tests.