### PR TITLE
Fix zero-extension in both literal conversion and assignment expansion

### DIFF
--- a/plugins/verilog_parser/src/verilog_parser.cpp
+++ b/plugins/verilog_parser/src/verilog_parser.cpp
@@ -137,7 +137,7 @@ namespace hal
                     // implicit "0"
                     for (u32 i = 0; i < left_size - right_size; i++)
                     {
-                        module.m_expanded_assignments.push_back(std::make_pair(left_signals.at(i), "0"));
+                        module.m_expanded_assignments.push_back(std::make_pair(left_signals.at(i + right_size), "'0'"));
                     }
                 }
             }

--- a/plugins/verilog_parser/src/verilog_parser.cpp
+++ b/plugins/verilog_parser/src/verilog_parser.cpp
@@ -1912,7 +1912,8 @@ namespace hal
         if (len != -1)
         {
             // fill with '0'
-            for (i32 i = 0; i < len - (i32)result.size(); i++)
+            i32 fill_width = len - (i32)result.size();
+            for (i32 i = 0; i < fill_width; i++)
             {
                 result.push_back("'0'");
             }


### PR DESCRIPTION
Faulty literal to binary conversion fill logic (due to a repeated evaluation of the loop condition which used the collection being modified's size) broke parsing the following valid code:
```verilog
module top(output [8:0] a);
    assign a[8:0] = 9'd0;
endmodule
```

Invalid implicit zero extension broke parsing the following valid code, where incorrect zeros (`"0"` rather than `"'0'"`) were added to incorrect bit positions (not shifted into the most significant bits).
```verilog
module top(output [1:0] a);
    assign a[1:0] = 1'd0;
endmodule
```

This PR (and the two contained commits) should fix both issues.