### PR TITLE
Grouping Dialog Fixes

### DIFF
--- a/plugins/gui/include/gui/grouping/grouping_table_model.h
+++ b/plugins/gui/include/gui/grouping/grouping_table_model.h
@@ -331,6 +331,8 @@ namespace hal {
     {
         static GroupingTableHistory* inst;
         GroupingTableHistory() {;}
+
+        static const int sMaxEntries;
     public:
         static GroupingTableHistory* instance();
         void add(u32 id);

--- a/plugins/gui/include/gui/grouping_dialog/grouping_dialog.h
+++ b/plugins/gui/include/gui/grouping_dialog/grouping_dialog.h
@@ -52,6 +52,13 @@ namespace hal {
          */
         u32 groupId() const { return mGroupId; }
 
+        /**
+         * Get the flag that states if a new grouping should be created.
+         *
+         * @return True if a new grouping should be created, False otherwise.
+         */
+        bool isNewGrouping() const { return mNewGrouping; }
+
     public Q_SLOTS:
         /**
          * Enables the dialog buttons if groupId is not zero and vice versa. If groupId is not zero and
@@ -90,5 +97,6 @@ namespace hal {
         QTabWidget* mTabWidget;
 
         u32 mGroupId;
+        bool mNewGrouping;
     };
 }

--- a/plugins/gui/include/gui/gui_utils/common_successor_predecessor.h
+++ b/plugins/gui/include/gui/gui_utils/common_successor_predecessor.h
@@ -26,6 +26,7 @@
 #include "hal_core/defines.h"
 #include <QHash>
 #include <QList>
+#include <QSet>
 #include "hal_core/netlist/gate.h"
 
 namespace hal {

--- a/plugins/gui/include/gui/gui_utils/common_successor_predecessor.h
+++ b/plugins/gui/include/gui/gui_utils/common_successor_predecessor.h
@@ -26,6 +26,7 @@
 #include "hal_core/defines.h"
 #include <QHash>
 #include <QList>
+#include "hal_core/netlist/gate.h"
 
 namespace hal {
     class Gate;

--- a/plugins/gui/include/gui/selection_details_widget/selection_details_widget.h
+++ b/plugins/gui/include/gui/selection_details_widget/selection_details_widget.h
@@ -310,18 +310,6 @@ namespace hal
         void toggleSearchbar();
 
         /**
-         * Creates a new grouping by calling addDefault() from the GroupingManagerWidget's model and adds
-         * the current selection to the grouping.
-         */
-        void selectionToNewGrouping();
-
-        /**
-         * Gets an existing grouping based on the before selected QAction in the ContextMenu created by
-         * selectionToGrouping() and adds the current selection to the grouping.
-         */
-        void selectionToExistingGrouping();
-
-        /**
          * Emits either the focusGateClicked, focusNetClicked or focusModuleClicked signal based on the
          * type of the clicked item.
          *

--- a/plugins/gui/src/graph_widget/graph_graphics_view.cpp
+++ b/plugins/gui/src/graph_widget/graph_graphics_view.cpp
@@ -1409,6 +1409,11 @@ namespace hal
     {
         GroupingDialog gd(this);
         if (gd.exec() != QDialog::Accepted) return;
+        if (gd.isNewGrouping())
+        {
+            gContentManager->getSelectionDetailsWidget()->selectionToGroupingAction();
+            return;
+        }
         QString groupName = QString::fromStdString(gNetlist->get_grouping_by_id(gd.groupId())->get_name());
         gContentManager->getSelectionDetailsWidget()->selectionToGroupingAction(groupName);
     }

--- a/plugins/gui/src/grouping/grouping_table_model.cpp
+++ b/plugins/gui/src/grouping/grouping_table_model.cpp
@@ -385,6 +385,8 @@ namespace hal {
     //---------------- HISTORY ----------------------------------------
     GroupingTableHistory* GroupingTableHistory::inst = nullptr;
 
+    const int GroupingTableHistory::sMaxEntries = 10;
+
     GroupingTableHistory* GroupingTableHistory::instance()
     {
         if (!inst)
@@ -396,6 +398,7 @@ namespace hal {
     {
         removeAll(id);
         prepend(id);
+        while (size() > sMaxEntries) takeLast();
     }
 
     //---------------- VIEW -------------------------------------------

--- a/plugins/gui/src/grouping_dialog/grouping_dialog.cpp
+++ b/plugins/gui/src/grouping_dialog/grouping_dialog.cpp
@@ -100,6 +100,7 @@ namespace hal {
     {
         Q_UNUSED(index);
         mGroupingTableView->clearSelection();
+        mSearchbar->clear();
         if (!GroupingTableHistory::instance()->isEmpty())
             mLastUsed->clearSelection();
     }

--- a/plugins/gui/src/grouping_dialog/grouping_dialog.cpp
+++ b/plugins/gui/src/grouping_dialog/grouping_dialog.cpp
@@ -17,7 +17,8 @@ namespace hal {
         : QDialog(parent),
           mSearchbar(new Searchbar(this)),
           mGroupingTableView(new GroupingTableView(false, this)),
-          mTabWidget(new QTabWidget(this))
+          mTabWidget(new QTabWidget(this)),
+          mNewGrouping(false)
     {
         setWindowTitle("Move to grouping …");
         QGridLayout* layout = new QGridLayout(this);
@@ -69,8 +70,8 @@ namespace hal {
 
     void GroupingDialog::handleNewGroupingClicked()
     {
-        ActionCreateObject* act = new ActionCreateObject(UserActionObjectType::Grouping);
-        act->exec();
+        mNewGrouping = true;
+        QDialog::accept();
     }
 
     void GroupingDialog::handleToggleSearchbar()

--- a/plugins/gui/src/selection_details_widget/selection_details_widget.cpp
+++ b/plugins/gui/src/selection_details_widget/selection_details_widget.cpp
@@ -224,6 +224,11 @@ namespace hal
     {
         GroupingDialog gd(this);
         if (gd.exec() != QDialog::Accepted) return;
+        if (gd.isNewGrouping())
+        {
+            selectionToGroupingAction();
+            return;
+        }
         QString groupName = QString::fromStdString(gNetlist->get_grouping_by_id(gd.groupId())->get_name());
         selectionToGroupingAction(groupName);
     }

--- a/plugins/gui/src/selection_details_widget/selection_details_widget.cpp
+++ b/plugins/gui/src/selection_details_widget/selection_details_widget.cpp
@@ -5,6 +5,7 @@
 #include "gui/selection_details_widget/net_details_widget.h"
 #include "gui/selection_details_widget/module_details_widget.h"
 #include "gui/module_dialog/module_dialog.h"
+#include "gui/grouping_dialog/grouping_dialog.h"
 #include "gui/grouping/grouping_manager_widget.h"
 #include "gui/graph_tab_widget/graph_tab_widget.h"
 #include "gui/user_action/action_add_items_to_object.h"
@@ -221,39 +222,10 @@ namespace hal
 
     void SelectionDetailsWidget::selectionToGrouping()
     {
-        QStringList groupingNames =
-                gContentManager->getGroupingManagerWidget()->getModel()->groupingNames();
-        if (groupingNames.isEmpty())
-            selectionToNewGrouping();
-        else
-        {
-            QMenu* contextMenu = new QMenu(this);
-
-            QAction* newGrouping = contextMenu->addAction("Create new grouping from selected items");
-            connect(newGrouping, &QAction::triggered, this, &SelectionDetailsWidget::selectionToNewGrouping);
-
-            contextMenu->addSeparator();
-
-            for (const QString& gn : groupingNames)
-            {
-                QAction* toGrouping = contextMenu->addAction(sAddToGrouping+gn);
-                connect(toGrouping, &QAction::triggered, this, &SelectionDetailsWidget::selectionToExistingGrouping);
-            }
-            contextMenu->exec(mapToGlobal(geometry().topLeft()+QPoint(100,0)));
-        }
-    }
-
-    void SelectionDetailsWidget::selectionToNewGrouping()
-    {
-        selectionToGroupingAction();
-    }
-
-    void SelectionDetailsWidget::selectionToExistingGrouping()
-    {
-        const QAction* action = static_cast<const QAction*>(QObject::sender());
-        QString grpName = action->text();
-        if (grpName.startsWith(sAddToGrouping)) grpName.remove(0,sAddToGrouping.size());
-        selectionToGroupingAction(grpName);
+        GroupingDialog gd(this);
+        if (gd.exec() != QDialog::Accepted) return;
+        QString groupName = QString::fromStdString(gNetlist->get_grouping_by_id(gd.groupId())->get_name());
+        selectionToGroupingAction(groupName);
     }
 
     UserAction* SelectionDetailsWidget::groupingUnassignActionFactory(const UserActionObject& obj) const


### PR DESCRIPTION
- Selection Details Widget: Move to grouping now opens grouping dialog
- Limit entries in 'Recent Selection' tab in grouping dialog (like module dialog)
- Clear search filter on tab change in grouping dialog (like module dialog)