### PR TITLE
Fix install_dependencies.sh scripts for macOS/arm64

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -14,36 +14,37 @@ if [[ "$platform" == 'macOS' ]]; then
     echo "Executing brew bundle"
     brew bundle
     pip3 install -r requirements.txt
+    BREW_PREFIX=$(brew --prefix)
     if [ -n "$($SHELL -c 'echo $ZSH_VERSION')" ]; then
-       grep -Fxq 'export PATH="/usr/local/opt/qt@5/bin:$PATH"' ~/.zshrc
+       grep -Fxq 'export PATH="$BREW_PREFIX/opt/qt@5/bin:$PATH"' ~/.zshrc
        if ! [[ $? -eq 0 ]]; then
-            echo 'export PATH="/usr/local/opt/qt@5/bin:$PATH"' >> ~/.zshrc
+            echo 'export PATH="$BREW_PREFIX/opt/qt@5/bin:$PATH"' >> ~/.zshrc
        fi
 
-       grep -Fxq 'export PATH="/usr/local/opt/flex/bin:$PATH"' ~/.zshrc
+       grep -Fxq 'export PATH="$BREW_PREFIX/opt/flex/bin:$PATH"' ~/.zshrc
        if ! [[ $? -eq 0 ]]; then
-            echo 'export PATH="/usr/local/opt/flex/bin:$PATH"' >> ~/.zshrc
+            echo 'export PATH="$BREW_PREFIX/opt/flex/bin:$PATH"' >> ~/.zshrc
        fi
 
-       grep -Fxq 'export PATH="/usr/local/opt/bison/bin:$PATH"' ~/.zshrc
+       grep -Fxq 'export PATH="$BREW_PREFIX/opt/bison/bin:$PATH"' ~/.zshrc
        if ! [[ $?  -eq 0 ]]; then
-            echo 'export PATH="/usr/local/opt/bison/bin:$PATH"' >> ~/.zshrc
+            echo 'export PATH="$BREW_PREFIX/opt/bison/bin:$PATH"' >> ~/.zshrc
        fi
        source ~/.zshrc
     elif [ -n "$($SHELL -c 'echo $BASH_VERSION')" ]; then
-       grep -Fxq 'export PATH="/usr/local/opt/qt@5/bin:$PATH"' ~/.bash_profile
+       grep -Fxq 'export PATH="$BREW_PREFIX/opt/qt@5/bin:$PATH"' ~/.bash_profile
        if ! [[ $? -eq 0 ]]; then
-            echo 'export PATH="/usr/local/opt/qt@5/bin:$PATH"' >> ~/.bash_profile
+            echo 'export PATH="$BREW_PREFIX/opt/qt@5/bin:$PATH"' >> ~/.bash_profile
        fi
 
-       grep -Fxq 'export PATH="/usr/local/opt/flex/bin:$PATH"' ~/.bash_profile
+       grep -Fxq 'export PATH="$BREW_PREFIX/opt/flex/bin:$PATH"' ~/.bash_profile
        if ! [[ $? -eq 0 ]]; then
-            echo 'export PATH="/usr/local/opt/flex/bin:$PATH"' >> ~/.bash_profile
+            echo 'export PATH="$BREW_PREFIX/opt/flex/bin:$PATH"' >> ~/.bash_profile
        fi
 
-       grep -Fxq 'export PATH="/usr/local/opt/bison/bin:$PATH"' ~/.bash_profile
+       grep -Fxq 'export PATH="$BREW_PREFIX/opt/bison/bin:$PATH"' ~/.bash_profile
        if ! [[ $?  -eq 0 ]]; then
-            echo 'export PATH="/usr/local/opt/bison/bin:$PATH"' >> ~/.bash_profile
+            echo 'export PATH="$BREW_PREFIX/opt/bison/bin:$PATH"' >> ~/.bash_profile
        fi
        source ~/.bash_profile
     else


### PR DESCRIPTION
Homebrew on macOS/arm64 (Apple Silicon) uses `/opt/homebrew` as prefix. This PR fixes `install_dependencies.sh` script to use `brew --prefix` which will work on all platforms.