### PR TITLE
Fix install_dependencies.sh for Arch Linux

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -62,8 +62,8 @@ elif [[ "$platform" == 'linux' ]]; then
         yay -S --needed base-devel lsb-release git cmake boost-libs pkgconf \
         qt5-base python ccache autoconf libsodium igraph qt5-svg ninja lcov \
         gcovr python-sphinx doxygen python-sphinx_rtd_theme python-jedi \
-        python-pip pybind11 rapidjson spdlog graphviz libsuitesparse-dev
-        sudo pip3 install -r requirements.txt
+        python-pip pybind11 rapidjson spdlog graphviz boost \
+        python-dateutil z3 
     else
        echo "Unsupported Linux distribution: abort!"
        exit 255


### PR DESCRIPTION
- System-wide Python packages should always be installed via the package manager under Arch Linux (see https://wiki.archlinux.org/title/Python#Package_management), so I removed the pip command and added `python-dateutil` to the dependencies.
- Furthermore, the dependencies `z3` and `boost` were added. 
- `libsuitesparse-dev` is not available on Arch Linux and is not needed for the build.