### PR TITLE
Bugfix: liberty parser now handles the NOT suffix character ' correctly.

### DIFF
--- a/include/hal_core/netlist/boolean_function/parser.h
+++ b/include/hal_core/netlist/boolean_function/parser.h
@@ -44,6 +44,7 @@ namespace hal
 
             And, /**< Boolean And operation (e.g., "&"). */
             Not, /**< Boolean Not operation (e.g., "!&"). */
+            NotSuffix, /** <Boolean Not operation as a expresion suffix (e.g., "'" for liberty grammar). */ 
             Or,  /**< Boolean Or operation (e.g., "|"). */
             Xor, /**< Boolean Xor operation (e.g., "^"). */
 
@@ -95,6 +96,13 @@ namespace hal
              * @returns The `NOT` token.
              */
             static Token Not();
+
+            /**
+             * Creates an `NOT_SUFFIX` token.
+             * 
+             * @returns The `NOT_SUFFIX` token.
+             */
+            static Token NotSuffix();
 
             /**
              * Creates an `OR` token.

--- a/src/netlist/boolean_function/parser_liberty.cpp
+++ b/src/netlist/boolean_function/parser_liberty.cpp
@@ -25,27 +25,7 @@ namespace hal
             const auto OrAction  = [&tokens](auto& /* ctx */) { tokens.emplace_back(BooleanFunctionParser::Token::Or()); };
             const auto XorAction = [&tokens](auto& /* ctx */) { tokens.emplace_back(BooleanFunctionParser::Token::Xor()); };
 
-            const auto NotSuffixAction = [&tokens](auto ctx) {
-                // The liberty format defines a ' character as an inversion of the
-                // previous expression. Since the only occurrences in the liberty
-                // file format belong to variables (e.g., " TE' "), we limit the
-                // ability of suffix not operations to variable expressions only.
-                //
-                // In case a suffix not operation may occur in complex expressions,
-                // we should introduce a special not token type that is then handled
-                // by the translation to the reverse polish notation.
-                if (tokens.empty() || (tokens.back().type != TokenType::Variable))
-                {
-                    log_error("netlist", "Cannot handle not suffix character ' in liberty parser as it is required that the predecessor token is a variable.");
-                    _pass(ctx) = false;
-                    return;
-                }
-                auto variable = tokens.back();
-                tokens.pop_back();
-
-                tokens.emplace_back(Token::Not());
-                tokens.emplace_back(variable);
-            };
+            const auto NotSuffixAction = [&tokens](auto& /* ctx */) { tokens.emplace_back(BooleanFunctionParser::Token::NotSuffix()); };
 
             const auto BracketOpenAction  = [&tokens](auto& /* ctx */) { tokens.emplace_back(BooleanFunctionParser::Token::BracketOpen()); };
             const auto BracketCloseAction = [&tokens](auto& /* ctx */) { tokens.emplace_back(BooleanFunctionParser::Token::BracketClose()); };
@@ -78,7 +58,7 @@ namespace hal
             const auto AndRule       = x3::char_("& *")[AndAction];
             const auto NotRule       = x3::lit("!")[NotAction];
             const auto NotSuffixRule = x3::lit("'")[NotSuffixAction];
-            const auto OrRule        = x3::lit("|+")[OrAction];
+            const auto OrRule        = x3::char_("|+")[OrAction];
             const auto XorRule       = x3::lit("^")[XorAction];
 
             const auto BracketOpenRule  = x3::lit("(")[BracketOpenAction];

--- a/src/netlist/boolean_function/parser_types.cpp
+++ b/src/netlist/boolean_function/parser_types.cpp
@@ -18,6 +18,11 @@ namespace hal
             return Token(TokenType::Not, {}, {});
         }
 
+        Token Token::NotSuffix()
+        {
+            return Token(TokenType::NotSuffix, {}, {});
+        }
+
         Token Token::Or()
         {
             return Token(TokenType::Or, {}, {});
@@ -53,6 +58,7 @@ namespace hal
             static const std::map<ParserType, std::map<TokenType, unsigned>> parser2precedence = {
                 {ParserType::Liberty,
                  std::map<TokenType, unsigned>({
+                     {TokenType::NotSuffix, 4},
                      {TokenType::Not, 4},
                      {TokenType::And, 3},
                      {TokenType::Xor, 2},
@@ -87,6 +93,7 @@ namespace hal
                 {TokenType::And, "And"},
                 {TokenType::Or, "Or"},
                 {TokenType::Not, "Not"},
+                {TokenType::NotSuffix, "NotSuffix"},
                 {TokenType::Xor, "Xor"},
 
                 {TokenType::BracketOpen, "BracketOpen"},
@@ -158,13 +165,24 @@ namespace hal
                         break;
                     }
 
-                    // (3) open brackets are always pushed into the operator stack
+                    // (3) the liberty grammar contains suffix not operations that
+                    //     invert the previous operation, i.e, acts similiar to  
+                    //     a "not" operation in reverse-polish notation. hence, 
+                    //     we simply push a "not" the output as the previous
+                    //     expression has been already translated to the reverse-
+                    //     polish notation in the output vector.
+                    case TokenType::NotSuffix: {
+                        output.emplace_back(Token::Not());
+                        break;
+                    }
+
+                    // (4) open brackets are always pushed into the operator stack
                     case TokenType::BracketOpen: {
                         operator_stack.push(token);
                         break;
                     }
 
-                    // (4) close brackets push remaining operations into the output
+                    // (5) close brackets push remaining operations into the output
                     //     queue until the bracket level is closed
                     case TokenType::BracketClose: {
                         while (!operator_stack.empty() && !operator_stack.top().is(TokenType::BracketOpen))

--- a/tests/netlist/boolean_function.cpp
+++ b/tests/netlist/boolean_function.cpp
@@ -204,6 +204,21 @@ namespace hal {
             {"A'", 
                 ~BooleanFunction::Var("A")
             },
+            {"RSTB'",
+                ~BooleanFunction::Var("RSTB")
+            },
+            {"(INP)'",
+                ~BooleanFunction::Var("INP")
+            },
+            {"(IN2*IN1)'",
+                ~(BooleanFunction::Var("IN2") & BooleanFunction::Var("IN1"))
+            },
+            {"(D'*CLK*RSTB*SETB')",
+                ~BooleanFunction::Var("D") & (BooleanFunction::Var("CLK") & (BooleanFunction::Var("RSTB") & ~BooleanFunction::Var("SETB"))) 
+            },
+            {"(IN5*(IN2+IN1)*(IN3+IN4))'",
+                ~(BooleanFunction::Var("IN5") & ((BooleanFunction::Var("IN2") | BooleanFunction::Var("IN1")) & (BooleanFunction::Var("IN3") | BooleanFunction::Var("IN4"))))
+            }
         };
 
         for (const auto& [s, expected] : data) {


### PR DESCRIPTION
The liberty file format allows for a NOT suffix that inverts the previous
expression in infix notation. We now handle the NOT suffix correctly for
general expressions and not only for variable inversions.