### PR TITLE
Boolean influence bug hunting

### DIFF
--- a/plugins/boolean_influence/src/plugin_boolean_influence.cpp
+++ b/plugins/boolean_influence/src/plugin_boolean_influence.cpp
@@ -117,12 +117,12 @@ namespace hal
             return {};
         }
         std::string data_pin = *d_ports.begin();
-        log_info("boolean_influence", "Data pin: {}", data_pin);
+        log_debug("boolean_influence", "Data pin: {}", data_pin);
 
         // Extract all gates in front of the data port and iterate backwards until another flip flop is found.
         std::vector<Gate*> function_gates = extract_function_gates(gate, data_pin);
 
-        log_info("boolean_influence", "Extracted {} gates infront of the gate.", function_gates.size());
+        log_debug("boolean_influence", "Extracted {} gates infront of the gate.", function_gates.size());
 
         // Generate function for the data port
 
@@ -132,7 +132,7 @@ namespace hal
 
         z3_utils::RecursiveSubgraphFunctionGenerator g = {*ctx, function_gates};
 
-        log_info("boolean_influence", "Created context, function and generator. Trying to generator function now: ");
+        log_debug("boolean_influence", "Created context, function and generator. Trying to generator function now: ");
 
         if (!function_gates.empty())
         {
@@ -149,7 +149,7 @@ namespace hal
 
         z3_utils::z3Wrapper func_wrapper = z3_utils::z3Wrapper(std::move(ctx), std::move(func));
 
-        log_info("boolean_influence", "Built subgraph function, now trying to extract boolean influence.");
+        log_debug("boolean_influence", "Built subgraph function, now trying to extract boolean influence.");
 
         // Generate boolean influence
         std::unordered_map<u32, double> net_ids_to_inf = func_wrapper.get_boolean_influence();

--- a/plugins/boolean_influence/test.py
+++ b/plugins/boolean_influence/test.py
@@ -2,7 +2,11 @@ from hal_plugins import boolean_influence
 
 pl = hal_py.plugin_manager.get_plugin_instance("boolean_influence")
 
-g = netlist.get_gate_by_id(1547)
+g = netlist.get_gate_by_id(66)
 inf = pl.get_boolean_influences_of_gate(g)
 
-print(inf)
+for net in inf:
+    print(net.name, inf[net])
+    
+import time
+print("Finished at {}".format(time.time()))

--- a/plugins/boolean_influence/test_multiple.py
+++ b/plugins/boolean_influence/test_multiple.py
@@ -1,0 +1,38 @@
+import sys, os
+
+hal_base_path = "/home/simon/projects/hal_4_0/hal/"
+dir_path = "/home/simon/playground/boolean_inf_test/netlists"
+gate_library_path = "/home/simon/projects/hal_4_0/hal/plugins/gate_libraries/definitions/lsi_10k.hgl"
+
+sys.path.append(hal_base_path + "build/lib/") #this is where your hal python lib is located
+os.environ["HAL_BASE_PATH"] = hal_base_path + "build" # hal base path
+
+import hal_py
+
+#initialize HAL
+hal_py.plugin_manager.load_all_plugins()
+
+from hal_plugins import boolean_influence
+
+pl = hal_py.plugin_manager.get_plugin_instance("boolean_influence")
+
+import glob
+
+files = glob.glob(dir_path + '/**/netlist/*.v', recursive=True)
+
+print(files)
+print(len(files))
+
+for file in files:
+    print("Getting influences in netlist {}".format(file))
+
+    netlist = hal_py.NetlistFactory.load_netlist(file, gate_library_path)
+
+    for gate in netlist.gates:
+        if gate.type.has_property(hal_py.GateTypeProperty.ff):
+            print("Gathering influences for gate {}".format(gate.id))   
+            inf = pl.get_boolean_influences_of_gate(gate)
+
+
+#unload everything hal related
+hal_py.plugin_manager.unload_all_plugins()

--- a/plugins/z3_utils/src/SubgraphFunctionGenerator.cpp
+++ b/plugins/z3_utils/src/SubgraphFunctionGenerator.cpp
@@ -320,7 +320,7 @@ namespace hal
 
         z3::expr RecursiveSubgraphFunctionGenerator::get_function_of_net(const Net* net, z3::context& ctx, const std::vector<Gate*>& subgraph_gates)
         {
-            log_info("z3_utils", "Trying to get function of net {}.", net->get_id());
+            log_debug("z3_utils", "Trying to get function of net {}.", net->get_id());
 
             if (m_expr_cache.find(net) != m_expr_cache.end())
             {
@@ -361,7 +361,7 @@ namespace hal
                 return ret;
             }
 
-            log_info("z3_utils", "Trying to get function of gate {}.", src->get_id());
+            log_debug("z3_utils", "Trying to get function of gate {}.", src->get_id());
 
             const BooleanFunction bf = get_function_of_gate(src, src_ep->get_pin()).optimize();
 
@@ -390,12 +390,12 @@ namespace hal
                 pin_to_expr.insert({pin, get_function_of_net(in_net, ctx, subgraph_gates)});
             }
 
-            log_info("z3_utils", "Got function of gate {}, converting to z3.", src->get_id());
+            log_debug("z3_utils", "Got function of gate {}, converting to z3.", src->get_id());
 
             z3::expr ret = bf.to_z3(ctx, pin_to_expr);
             m_expr_cache.insert({net, ret});
 
-            log_info("z3_utils", "Returning function of net {}.", net->get_id());
+            log_debug("z3_utils", "Returning function of net {}.", net->get_id());
 
             return ret;
         }

--- a/plugins/z3_utils/src/z3Wrapper.cpp
+++ b/plugins/z3_utils/src/z3Wrapper.cpp
@@ -132,11 +132,11 @@ namespace hal
             std::string directory = "/tmp/boolean_influence_tmp/";
             std::filesystem::create_directory(directory);
 
-            log_debug("z3_utils", "directory created");
+            log_info("z3_utils", "directory created");
 
             std::string filename = directory + "boolean_func_" + std::to_string(omp_get_thread_num()) + "_" + std::to_string(m_z3_wrapper_id) + ".cpp";
 
-            log_debug("z3_utils", "creating file: {}", filename);
+            log_info("z3_utils", "creating file: {}", filename);
 
             if (!this->write_c_file(filename))
             {
@@ -144,14 +144,14 @@ namespace hal
                 return std::unordered_map<u32, double>();
             }
 
-            log_debug("z3_utils", "file created: {}", filename);
+            log_info("z3_utils", "file created: {}", filename);
 
             const std::string program_name    = filename.substr(0, filename.size() - 2);
             const std::string compile_command = "g++ -o " + program_name + " " + filename + " -O3";
             int res = system(compile_command.c_str());
             UNUSED(res);
 
-            log_debug("z3_utils", "{}", compile_command);
+            log_info("z3_utils", "{}", compile_command);
 
             // run boolean function program for every input
             for (auto it = m_inputs_net_ids.begin(); it < m_inputs_net_ids.end(); it++)
@@ -161,7 +161,7 @@ namespace hal
                 std::array<char, 128> buffer;
                 std::string result;
 
-                log_debug("z3_utils", "{}", run_command);
+                log_info("z3_utils", "{}", run_command);
 
                 FILE* pipe = popen(run_command.c_str(), "r");
                 if (!pipe)
@@ -178,7 +178,7 @@ namespace hal
                 const u32 count = std::stoi(result);
                 double cv       =  (double)(count) / (double)(num_evaluations);
 
-                log_debug("z3_utils", "calculation done");
+                log_info("z3_utils", "calculation done");
 
                 influences.insert({*it, cv});
             }
@@ -189,7 +189,7 @@ namespace hal
 
             //std::filesystem::remove(directory);
 
-            log_debug("z3_utils", "returning influences");
+            log_info("z3_utils", "returning influences");
 
             return influences;
         }

--- a/plugins/z3_utils/src/z3Wrapper.cpp
+++ b/plugins/z3_utils/src/z3Wrapper.cpp
@@ -132,11 +132,11 @@ namespace hal
             std::string directory = "/tmp/boolean_influence_tmp/";
             std::filesystem::create_directory(directory);
 
-            log_info("z3_utils", "directory created");
+            log_debug("z3_utils", "directory created");
 
             std::string filename = directory + "boolean_func_" + std::to_string(omp_get_thread_num()) + "_" + std::to_string(m_z3_wrapper_id) + ".cpp";
 
-            log_info("z3_utils", "creating file: {}", filename);
+            log_debug("z3_utils", "creating file: {}", filename);
 
             if (!this->write_c_file(filename))
             {
@@ -144,14 +144,14 @@ namespace hal
                 return std::unordered_map<u32, double>();
             }
 
-            log_info("z3_utils", "file created: {}", filename);
+            log_debug("z3_utils", "file created: {}", filename);
 
             const std::string program_name    = filename.substr(0, filename.size() - 2);
             const std::string compile_command = "g++ -o " + program_name + " " + filename + " -O3";
             int res = system(compile_command.c_str());
             UNUSED(res);
 
-            log_info("z3_utils", "{}", compile_command);
+            log_debug("z3_utils", "{}", compile_command);
 
             // run boolean function program for every input
             for (auto it = m_inputs_net_ids.begin(); it < m_inputs_net_ids.end(); it++)
@@ -161,7 +161,7 @@ namespace hal
                 std::array<char, 128> buffer;
                 std::string result;
 
-                log_info("z3_utils", "{}", run_command);
+                log_debug("z3_utils", "{}", run_command);
 
                 FILE* pipe = popen(run_command.c_str(), "r");
                 if (!pipe)
@@ -178,7 +178,7 @@ namespace hal
                 const u32 count = std::stoi(result);
                 double cv       =  (double)(count) / (double)(num_evaluations);
 
-                log_info("z3_utils", "calculation done");
+                log_debug("z3_utils", "calculation done");
 
                 influences.insert({*it, cv});
             }
@@ -189,7 +189,7 @@ namespace hal
 
             //std::filesystem::remove(directory);
 
-            log_info("z3_utils", "returning influences");
+            log_debug("z3_utils", "returning influences");
 
             return influences;
         }


### PR DESCRIPTION
Changed the subgraph function generator for the z3 utils and copied the get_function_of_gate() function from the 4.0 version that takes internal nets into account. This seems to get rid of some bugs that occured when gathering boolean influences.