### PR TITLE
Fix crash on Python console reset() and clear()

### DIFF
--- a/plugins/gui/include/gui/python/python_context.h
+++ b/plugins/gui/include/gui/python/python_context.h
@@ -135,12 +135,12 @@ namespace hal
          * Clears the python console.
          *
          */
-        void forwardClear();
+        void scheduleClear();
 
         /**
          * Resets the python console.
          */
-        void forwardReset();
+        void scheduleReset();
 
         /**
          * Assign this object the python console to work with.
@@ -205,6 +205,7 @@ namespace hal
     private:
 
         void handleReset();
+        void handleClear();
 
         // these have to be pointers, otherwise they are destructed after py::finalize_interpreter and segfault
         // only one object for global and local is needed, as for the console we run it always in global scope wher globals() == locals()
@@ -216,6 +217,7 @@ namespace hal
 
         PythonConsole* mConsole;
         bool mTriggerReset;
+        bool mTriggerClear;
         LayoutLocker* mLayoutLocker;
         PythonThread* mThread;
         bool mThreadAborted;

--- a/plugins/gui/src/python/python_context.cpp
+++ b/plugins/gui/src/python/python_context.cpp
@@ -562,7 +562,9 @@ namespace hal
         if (mTriggerReset)
         {
             closePython();
+            PyGILState_STATE state = PyGILState_Ensure();
             initPython();
+            PyGILState_Release(state);
             forwardClear();
             mTriggerReset = false;
         }

--- a/plugins/gui/src/python/python_context.cpp
+++ b/plugins/gui/src/python/python_context.cpp
@@ -425,10 +425,23 @@ namespace hal
             forwardError(errmsg);
 
         if (calledFromEditor)
+        {
             calledFromEditor->handleThreadFinished();
+            if (mTriggerReset)
+            {
+                forwardError("\nreset() can only be used in the Python console!\n");
+                mTriggerReset = false;
+            }
+            if (mTriggerClear)
+            {
+                forwardError("\nclear() can only be used in the Python console!\n");
+                mTriggerClear = false;
+            }
+        }
         else if (mConsole)
         {
             handleReset();
+            handleClear();
             mConsole->handleThreadFinished();
         }
 
@@ -457,14 +470,6 @@ namespace hal
         if (mConsole)
         {
             mConsole->handleError(output);
-        }
-    }
-
-    void PythonContext::forwardClear()
-    {
-        if (mConsole)
-        {
-            mConsole->clear();
         }
     }
 
@@ -565,14 +570,31 @@ namespace hal
             PyGILState_STATE state = PyGILState_Ensure();
             initPython();
             PyGILState_Release(state);
-            forwardClear();
+            scheduleClear();
             mTriggerReset = false;
         }
     }
 
-    void PythonContext::forwardReset()
+    void PythonContext::handleClear()
+    {
+        if (mTriggerClear)
+        {
+            if (mConsole)
+            {
+                mConsole->clear();
+            }
+            mTriggerClear = false;
+        }
+    }
+
+    void PythonContext::scheduleReset()
     {
         mTriggerReset = true;
+    }
+
+    void PythonContext::scheduleClear()
+    {
+        mTriggerClear = true;
     }
 
     void PythonContext::updateNetlist()

--- a/plugins/gui/src/python/python_gui_api_bindings.cpp
+++ b/plugins/gui/src/python/python_gui_api_bindings.cpp
@@ -36,8 +36,8 @@ PYBIND11_PLUGIN(hal_gui)
         GUI Console
     )");
 
-    py_console.def("clear", []() -> void { gPythonContext->forwardClear(); });
-    py_console.def("reset", []() -> void { gPythonContext->forwardReset(); });
+    py_console.def("clear", []() -> void { gPythonContext->scheduleClear(); });
+    py_console.def("reset", []() -> void { gPythonContext->scheduleReset(); });
 
     //m.def("history", []() -> void { g_console->printHistory(g_console->m_cmdColor); });
 

--- a/plugins/gui/src/python/python_thread.cpp
+++ b/plugins/gui/src/python/python_thread.cpp
@@ -124,7 +124,7 @@ namespace hal {
         }
         else if (nThreads > 1)
         {
-            // apparently this can acRetually happen if you mess up the C<->Python bindings
+            // apparently this can actually happen if you mess up the C<->Python bindings
             qDebug() << "Oh no! There seem to be multiple threads with the same ID!";
         }
         PyGILState_Release(state);


### PR DESCRIPTION
Threading turned out really nice, @joern274 ! There was a really small issue with the meta-functions for clearing and resetting the console. Resetting would not acquire the GIL and clearing would try to run on the Python thread rather the UI one, both causing segfaults. Here's a small patch for that.