### PR TITLE
Fix some crashes when closing the document

### DIFF
--- a/plugins/gui/include/gui/python/python_console.h
+++ b/plugins/gui/include/gui/python/python_console.h
@@ -68,6 +68,7 @@ namespace hal
          * Constructor.
          */
         PythonConsole(QWidget* parent = nullptr);
+        ~PythonConsole();
 
         enum PromptType { Standard, Compound, Input };
 

--- a/plugins/gui/include/gui/python/python_context.h
+++ b/plugins/gui/include/gui/python/python_context.h
@@ -193,6 +193,7 @@ namespace hal
         static void initializeScript(py::dict* context);
 
         void abortThread();
+        void abortThreadAndWait();
         bool isThreadRunning() const { return mThread != nullptr; }
 
     private Q_SLOTS:

--- a/plugins/gui/src/main_window/main_window.cpp
+++ b/plugins/gui/src/main_window/main_window.cpp
@@ -879,6 +879,8 @@ namespace hal
                 return false;
         }
 
+        gPythonContext->abortThreadAndWait();
+
         gGraphContextManager->clear();
 
         clear();

--- a/plugins/gui/src/python/python_console.cpp
+++ b/plugins/gui/src/python/python_console.cpp
@@ -37,6 +37,11 @@ namespace hal
         mAbortThreadWidget = new PythonConsoleAbortThread(this);
     }
 
+    PythonConsole::~PythonConsole()
+    {
+        gPythonContext->setConsole(nullptr);
+    }
+
     void PythonConsole::keyPressEventInputMode(QKeyEvent *e)
     {
         mCurrentHistoryIndex = -1;

--- a/plugins/gui/src/python/python_context.cpp
+++ b/plugins/gui/src/python/python_context.cpp
@@ -86,9 +86,14 @@ namespace hal
     {
         if (!mThread) return;
         mThreadAborted = true;
-        qDebug() << "Issue interrupt ...";
         mThread->interrupt();
-        qDebug() << "Done interrupt";
+    }
+
+    void PythonContext::abortThreadAndWait()
+    {
+        if (!mThread) return;
+        abortThread();
+        mThread->wait();
     }
 
     void PythonContext::initializeContext(py::dict* context)

--- a/plugins/gui/src/python/python_context.cpp
+++ b/plugins/gui/src/python/python_context.cpp
@@ -70,8 +70,11 @@ namespace hal
 
     void PythonContext::setConsole(PythonConsole* c)
     {
-        mConsole = c;
-        connect(mConsole,&PythonConsole::inputReceived,this,&PythonContext::handleConsoleInputReceived);
+        mConsole = c; // may be nullptr
+        if (c)
+        {
+            connect(mConsole,&PythonConsole::inputReceived,this,&PythonContext::handleConsoleInputReceived);
+        }
     }
 
     PythonThread* PythonContext::currentThread() const

--- a/plugins/gui/src/python/python_context.cpp
+++ b/plugins/gui/src/python/python_context.cpp
@@ -175,6 +175,7 @@ namespace hal
 
     void PythonContext::closePython()
     {
+        // GIL must be held
         delete mContext;
         mContext = nullptr;
     }
@@ -566,8 +567,8 @@ namespace hal
     {
         if (mTriggerReset)
         {
-            closePython();
             PyGILState_STATE state = PyGILState_Ensure();
+            closePython();
             initPython();
             PyGILState_Release(state);
             scheduleClear();
@@ -599,7 +600,9 @@ namespace hal
 
     void PythonContext::updateNetlist()
     {
+        PyGILState_STATE state = PyGILState_Ensure();
         (*mContext)["netlist"] = gNetlistOwner;    // assign the shared_ptr here, not the raw ptr
+        PyGILState_Release(state);
     }
 
 }    // namespace hal


### PR DESCRIPTION
During tesing, I stumbled upon a few more crashes that occur around opening/closing documents:

- When switching to another document, we need to ensure that the Python GIL is held before updating references to the Netlist in Python
- Long-running Python threads should not survive closure of the document (memory inconsistency issues arise otherwise)
- The Python console should deregister before being deleted to prevent dangling pointers

This PR should fix all three, though I'd appreciate @joern274 's feedback on the latter two issues (most recent two commits) regarding whether I handled the Qt side of things properly.