### PR TITLE
Docker Container improvement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,26 @@
-FROM ubuntu:focal
+FROM ubuntu:22.04
 
-ENV build_path=/home/build
-RUN mkdir -p $build_path
-WORKDIR $build_path
+ARG CMAKE_OPTIONS
+ARG MAKE_OPTIONS
+
+ENV hal_path=/hal
+RUN mkdir -p $hal_path
+WORKDIR $hal_path
+
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 RUN sed -i -e 's/#force_color_prompt=yes/force_color_prompt=yes/g' /root/.bashrc
-RUN apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg software-properties-common curl \
-    build-essential lsb-release git cmake pkgconf libspdlog-dev libboost-all-dev qt5-default libpython3.8-dev \
-    pybind11-dev  build-essential libyaml-cpp-dev ccache autoconf autotools-dev flex bison libsodium-dev libqt5svg5-dev libqt5svg5* ninja-build lcov gcovr graphviz \
-    python3-sphinx doxygen python3-sphinx-rtd-theme python3-jedi flex bison devscripts debhelper dh-make pkgconf gnupg2 pybind11-dev python3-pybind11 \
-    python3-paramiko rapidjson-dev libspdlog-dev libigraph0-dev python3-dateutil libz3-dev libomp-dev\
-      && apt-get clean \
-      && rm -rf /var/lib/apt/lists/*
-CMD cmake -G Ninja /home/src -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_ALL_PLUGINS=OFF -DPL_GRAPH_ALGORITHM=ON -DPL_GATE_DECORATOR_SYSTEM=ON -DBUILD_TESTS=ON -PL_GUI=ON -DCMAKE_INSTALL_PREFIX=/usr/ -DCPACK_OUTPUT_FILE_PREFIX=/home/build-output/ && \
-    cmake --build /home/build --target package --clean-first -- -j4
+
+RUN apt-get update -y && \
+    apt-get install -y lsb-release
+
+COPY . .
+RUN ./install_dependencies.sh
+
+RUN mkdir build
+WORKDIR ${hal_path}/build/
+RUN cmake .. ${CMAKE_OPTIONS}
+RUN make ${MAKE_OPTIONS}
+
+VOLUME [ "/projects" ]
+
+CMD ["./bin/hal", "-g"]

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -4,7 +4,11 @@ platform='unknown'
 unamestr=$(uname)
 distribution='unknown'
 release='unknown'
-if [[ "$unamestr" == 'Linux' ]]; then
+if [[ -f "/.dockerenv" ]]; then
+   platform='docker'
+   distribution=$(lsb_release -is)
+   release=$(lsb_release -rs)
+elif [[ "$unamestr" == 'Linux' ]]; then
    platform='linux'
    distribution=$(lsb_release -is)
    release=$(lsb_release -rs)
@@ -93,4 +97,15 @@ elif [[ "$platform" == 'linux' ]]; then
        echo "Unsupported Linux distribution: abort!"
        exit 255
     fi
+elif [[ "$platform" == 'docker' ]]; then
+    # We can assume that we are in a ubuntu container, because of the official Dockerfile in the hal project
+    apt-get update && apt-get install -y build-essential verilator \
+    lsb-release git cmake pkgconf libboost-all-dev qtbase5-dev \
+    libpython3-dev ccache autoconf autotools-dev libsodium-dev \
+    libqt5svg5-dev libqt5svg5* ninja-build lcov gcovr python3-sphinx \
+    doxygen python3-sphinx-rtd-theme python3-jedi python3-pip \
+    pybind11-dev python3-pybind11 rapidjson-dev libspdlog-dev libz3-dev libreadline-dev \
+    libigraph-dev \
+    graphviz libomp-dev libsuitesparse-dev # For documentation
+    pip3 install -r requirements.txt
 fi


### PR DESCRIPTION
The container should use the same build steps as when you install HAL on your local system.

For this purpose the `Dockerfile` and the `install_dependencies.sh` script were adapted accordingly.

First you have to build the container, replacing `$YOUR_CMAKE_OPTIONS` and `$YOUR_MAKE_OPTIONS` with the appropriate options:
`docker build --build-arg=CMAKE_OPTIONS=$YOUR_CMAKE_OPTIONS --build-arg=MAKE_OPTIONS=$YOUR_MAKE_OPTIONS -t emsec/hal:latest .`

The container can be started at least under Linux with:
`xhost + 'local:docker@' && docker run -dit --name hal -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -v $/PATH/TO/YOUR/PROJECTS/FOLDER/:/projects/ emsec/hal:latest`
Here `$/PATH/TO/YOUR/PROJECTS/FOLDER/` should be replaced with the folder where the projects to be processed are located.

After starting the container, the known HAL gui opens and under `/projects` you can find all your projects to edit.