### PR TITLE
Fix/verilog parser explicit port assign bug

### DIFF
--- a/plugins/verilog_parser/include/verilog_parser/verilog_parser.h
+++ b/plugins/verilog_parser/include/verilog_parser/verilog_parser.h
@@ -95,7 +95,6 @@ namespace hal
             std::string m_expression;
             PinDirection m_direction;
             std::vector<std::vector<u32>> m_ranges;
-            std::vector<VerilogDataEntry> m_attributes;
             std::vector<std::string> m_expanded_identifiers;
         };
 
@@ -182,7 +181,7 @@ namespace hal
         std::unordered_map<std::string, GateType*> m_vcc_gate_types;
         std::unordered_map<std::string, GateType*> m_gnd_gate_types;
         std::unordered_map<Net*, std::vector<std::pair<Module*, u32>>> m_module_port_by_net;
-        std::unordered_map<Module*, std::vector<std::tuple<std::string, PinDirection, Net*>>> m_module_ports;
+        std::unordered_map<Module*, std::vector<std::tuple<std::string, Net*>>> m_module_ports;
 
         // unique aliases
         std::unordered_map<std::string, u32> m_signal_name_occurrences;
@@ -192,7 +191,7 @@ namespace hal
         Net* m_zero_net;
         Net* m_one_net;
         std::unordered_map<std::string, Net*> m_net_by_name;
-        std::unordered_map<std::string, std::vector<std::string>> m_nets_to_merge;
+        std::vector<std::pair<std::string, std::string>> m_nets_to_merge;
 
         // parse HDL into intermediate format
         void tokenize();

--- a/plugins/verilog_parser/src/verilog_parser.cpp
+++ b/plugins/verilog_parser/src/verilog_parser.cpp
@@ -683,18 +683,31 @@ namespace hal
                 }
                 ports_stream.consume();
 
-                auto port          = std::make_unique<VerilogPort>();
-                port->m_identifier = next_token.string;
-                port->m_expression = next_token.string;
-                port->m_direction  = direction;
+                auto port                          = std::make_unique<VerilogPort>();
+                const std::string& port_expression = next_token.string;
+                port->m_identifier                 = port_expression;
+                port->m_expression                 = port_expression;
+                port->m_direction                  = direction;
                 if (!ranges.empty())
                 {
                     port->m_ranges = ranges;
                 }
-
-                verilog_module->m_ports_by_identifier[port->m_identifier] = port.get();
-                verilog_module->m_ports_by_expression[port->m_expression] = port.get();
+                verilog_module->m_ports_by_identifier[port_expression] = port.get();
+                verilog_module->m_ports_by_expression[port_expression] = port.get();
                 verilog_module->m_ports.push_back(std::move(port));
+
+                // every port is an implicit wire, so create signal if not alreaedy declared explicitly
+                if (verilog_module->m_signals_by_name.find(port_expression) == verilog_module->m_signals_by_name.end())
+                {
+                    auto signal    = std::make_unique<VerilogSignal>();
+                    signal->m_name = port_expression;
+                    if (!ranges.empty())
+                    {
+                        signal->m_ranges = ranges;
+                    }
+                    verilog_module->m_signals_by_name[port_expression] = signal.get();
+                    verilog_module->m_signals.push_back(std::move(signal));
+                }
             } while (ports_stream.consume(",", ports_stream.remaining() > 0));
         }
 
@@ -743,7 +756,25 @@ namespace hal
             {
                 port->m_ranges = ranges;
             }
-            port->m_attributes.insert(port->m_attributes.end(), attributes.begin(), attributes.end());
+
+            // every port is an implicit wire, so create signal if not alreaedy declared explicitly
+            if (const auto signal_it = verilog_module->m_signals_by_name.find(port_expression); signal_it == verilog_module->m_signals_by_name.end())
+            {
+                auto signal    = std::make_unique<VerilogSignal>();
+                signal->m_name = port_expression;
+                if (!ranges.empty())
+                {
+                    signal->m_ranges = ranges;
+                }
+                signal->m_attributes.insert(signal->m_attributes.end(), attributes.begin(), attributes.end());
+                verilog_module->m_signals_by_name[port_expression] = signal.get();
+                verilog_module->m_signals.push_back(std::move(signal));
+            }
+            else
+            {
+                auto* signal = signal_it->second;
+                signal->m_attributes.insert(signal->m_attributes.end(), attributes.begin(), attributes.end());
+            }
         } while (m_token_stream.consume(",", false));
 
         m_token_stream.consume(";", true);
@@ -790,15 +821,24 @@ namespace hal
                 verilog_module->m_assignments.push_back(std::move(assignment));
             }
 
-            auto signal    = std::make_unique<VerilogSignal>();
-            signal->m_name = signal_name.string;
-            if (!ranges.empty())
+            // create signal if not already implicitly declared otherwise
+            if (const auto signal_it = verilog_module->m_signals_by_name.find(signal_name.string); signal_it == verilog_module->m_signals_by_name.end())
             {
-                signal->m_ranges = ranges;
+                auto signal    = std::make_unique<VerilogSignal>();
+                signal->m_name = signal_name.string;
+                if (!ranges.empty())
+                {
+                    signal->m_ranges = ranges;
+                }
+                signal->m_attributes.insert(signal->m_attributes.end(), attributes.begin(), attributes.end());
+                verilog_module->m_signals_by_name[signal_name.string] = signal.get();
+                verilog_module->m_signals.push_back(std::move(signal));
             }
-            signal->m_attributes.insert(signal->m_attributes.end(), attributes.begin(), attributes.end());
-            verilog_module->m_signals_by_name[signal_name.string] = signal.get();
-            verilog_module->m_signals.push_back(std::move(signal));
+            else
+            {
+                auto* signal = signal_it->second;
+                signal->m_attributes.insert(signal->m_attributes.end(), attributes.begin(), attributes.end());
+            }
 
         } while (signal_stream.consume(",", false));
 
@@ -1040,15 +1080,6 @@ namespace hal
         std::queue<VerilogModule*> q;
         q.push(top_module);
 
-        // global input/output signals will be named after ports, so take into account for aliases
-        for (const auto& port : top_module->m_ports)
-        {
-            for (const auto& expanded_port_identifier : port->m_expanded_identifiers)
-            {
-                m_signal_name_occurrences[expanded_port_identifier]++;
-            }
-        }
-
         while (!q.empty())
         {
             VerilogModule* module = q.front();
@@ -1159,22 +1190,24 @@ namespace hal
         {
             for (const auto& expanded_port_identifier : port->m_expanded_identifiers)
             {
-                Net* global_port_net = m_netlist->create_net(expanded_port_identifier);
+                const auto signal_name = get_unique_alias(m_signal_name_occurrences, expanded_port_identifier);
+
+                Net* global_port_net = m_netlist->create_net(signal_name);
                 if (global_port_net == nullptr)
                 {
-                    return ERR("could not construct netlist: failed to create global I/O net '" + expanded_port_identifier + "'");
+                    return ERR("could not construct netlist: failed to create global I/O net '" + signal_name + "'");
                 }
 
-                m_net_by_name[expanded_port_identifier] = global_port_net;
+                m_net_by_name[signal_name] = global_port_net;
 
                 // assign global port nets to ports of top module
-                top_assignments[expanded_port_identifier] = expanded_port_identifier;
+                top_assignments[signal_name] = signal_name;
 
                 if (port->m_direction == PinDirection::input || port->m_direction == PinDirection::inout)
                 {
                     if (!global_port_net->mark_global_input_net())
                     {
-                        return ERR("could not construct netlist: failed to mark global I/O net '" + expanded_port_identifier + "' as global input");
+                        return ERR("could not construct netlist: failed to mark global I/O net '" + signal_name + "' as global input");
                     }
                 }
 
@@ -1182,7 +1215,7 @@ namespace hal
                 {
                     if (!global_port_net->mark_global_output_net())
                     {
-                        return ERR("could not construct netlist: failed to mark global I/O net '" + expanded_port_identifier + "' as global output");
+                        return ERR("could not construct netlist: failed to mark global I/O net '" + signal_name + "' as global output");
                     }
                 }
             }
@@ -1194,123 +1227,122 @@ namespace hal
         }
 
         // merge nets without gates in between them
-        while (!m_nets_to_merge.empty())
+        std::unordered_map<std::string, std::string> merged_nets;
+
+        for (auto& [master, slave] : m_nets_to_merge)
         {
-            // master = net that other nets are merged into
-            // slave = net to merge into master and then delete
-            bool progress_made = false;
-
-            for (const auto& [master, merge_set] : m_nets_to_merge)
+            // check if master net has already been merged into other net
+            while (true)
             {
-                // check if none of the slaves is itself a master
-                bool is_master = false;
-                for (const auto& slave : merge_set)
+                if (const auto master_it = merged_nets.find(master); master_it != merged_nets.end())
                 {
-                    if (m_nets_to_merge.find(slave) != m_nets_to_merge.end())
-                    {
-                        is_master = true;
-                        break;
-                    }
+                    master = master_it->second;
                 }
-
-                if (is_master)
+                else
                 {
-                    continue;
+                    break;
                 }
-
-                auto master_net = m_net_by_name.at(master);
-                for (const auto& slave : merge_set)
-                {
-                    auto slave_net = m_net_by_name.at(slave);
-
-                    // merge sources
-                    if (slave_net->is_global_input_net())
-                    {
-                        master_net->mark_global_input_net();
-                    }
-
-                    for (auto src : slave_net->get_sources())
-                    {
-                        Gate* src_gate   = src->get_gate();
-                        GatePin* src_pin = src->get_pin();
-
-                        if (!slave_net->remove_source(src))
-                        {
-                            return ERR("could not construct netlist: failed to remove source from net '" + slave_net->get_name() + "' with ID " + std::to_string(slave_net->get_id()));
-                        }
-
-                        if (!master_net->is_a_source(src_gate, src_pin))
-                        {
-                            if (!master_net->add_source(src_gate, src_pin))
-                            {
-                                return ERR("could not construct netlist: failed to add source to net '" + master_net->get_name() + "' with ID " + std::to_string(master_net->get_id()));
-                            }
-                        }
-                    }
-
-                    // merge destinations
-                    if (slave_net->is_global_output_net())
-                    {
-                        master_net->mark_global_output_net();
-                    }
-
-                    for (auto dst : slave_net->get_destinations())
-                    {
-                        Gate* dst_gate   = dst->get_gate();
-                        GatePin* dst_pin = dst->get_pin();
-
-                        if (!slave_net->remove_destination(dst))
-                        {
-                            return ERR("could not construct netlist: failed to remove destination from net '" + slave_net->get_name() + "' with ID " + std::to_string(slave_net->get_id()));
-                        }
-
-                        if (!master_net->is_a_destination(dst_gate, dst_pin))
-                        {
-                            if (!master_net->add_destination(dst_gate, dst_pin))
-                            {
-                                return ERR("could not construct netlist: failed to add destination to net '" + master_net->get_name() + "' with ID " + std::to_string(master_net->get_id()));
-                            }
-                        }
-                    }
-
-                    // merge generics and attributes
-                    for (const auto& [identifier, content] : slave_net->get_data_map())
-                    {
-                        if (!master_net->set_data(std::get<0>(identifier), std::get<1>(identifier), std::get<0>(content), std::get<1>(content)))
-                        {
-                            log_warning("verilog_parser",
-                                        "unable to transfer data from slave net '{}' with ID {} to master net '{}' with ID {}.",
-                                        slave_net->get_name(),
-                                        slave_net->get_id(),
-                                        master_net->get_name(),
-                                        master_net->get_id());
-                        }
-                    }
-
-                    // update module ports
-                    if (const auto it = m_module_port_by_net.find(slave_net); it != m_module_port_by_net.end())
-                    {
-                        for (auto [module, index] : it->second)
-                        {
-                            std::get<2>(m_module_ports.at(module).at(index)) = master_net;
-                        }
-                        m_module_port_by_net[master_net].insert(m_module_port_by_net[master_net].end(), it->second.begin(), it->second.end());
-                        m_module_port_by_net.erase(it);
-                    }
-
-                    m_netlist->delete_net(slave_net);
-                    m_net_by_name.erase(slave);
-                }
-
-                m_nets_to_merge.erase(master);
-                progress_made = true;
-                break;
             }
 
-            if (!progress_made)
+            // check if slave net has already been merged into other net
+            while (true)
             {
-                return ERR("could not construct netlist: cyclic dependency between signals detected");
+                if (const auto slave_it = merged_nets.find(slave); slave_it != merged_nets.end())
+                {
+                    slave = slave_it->second;
+                }
+                else
+                {
+                    break;
+                }
             }
+
+            auto master_net = m_net_by_name.at(master);
+            auto slave_net  = m_net_by_name.at(slave);
+
+            if (master_net == slave_net)
+            {
+                continue;
+            }
+
+            // merge sources
+            if (slave_net->is_global_input_net())
+            {
+                master_net->mark_global_input_net();
+            }
+
+            for (auto src : slave_net->get_sources())
+            {
+                Gate* src_gate   = src->get_gate();
+                GatePin* src_pin = src->get_pin();
+
+                if (!slave_net->remove_source(src))
+                {
+                    return ERR("could not construct netlist: failed to remove source from net '" + slave_net->get_name() + "' with ID " + std::to_string(slave_net->get_id()));
+                }
+
+                if (!master_net->is_a_source(src_gate, src_pin))
+                {
+                    if (!master_net->add_source(src_gate, src_pin))
+                    {
+                        return ERR("could not construct netlist: failed to add source to net '" + master_net->get_name() + "' with ID " + std::to_string(master_net->get_id()));
+                    }
+                }
+            }
+
+            // merge destinations
+            if (slave_net->is_global_output_net())
+            {
+                master_net->mark_global_output_net();
+            }
+
+            for (auto dst : slave_net->get_destinations())
+            {
+                Gate* dst_gate   = dst->get_gate();
+                GatePin* dst_pin = dst->get_pin();
+
+                if (!slave_net->remove_destination(dst))
+                {
+                    return ERR("could not construct netlist: failed to remove destination from net '" + slave_net->get_name() + "' with ID " + std::to_string(slave_net->get_id()));
+                }
+
+                if (!master_net->is_a_destination(dst_gate, dst_pin))
+                {
+                    if (!master_net->add_destination(dst_gate, dst_pin))
+                    {
+                        return ERR("could not construct netlist: failed to add destination to net '" + master_net->get_name() + "' with ID " + std::to_string(master_net->get_id()));
+                    }
+                }
+            }
+
+            // merge generics and attributes
+            for (const auto& [identifier, content] : slave_net->get_data_map())
+            {
+                if (!master_net->set_data(std::get<0>(identifier), std::get<1>(identifier), std::get<0>(content), std::get<1>(content)))
+                {
+                    log_warning("verilog_parser",
+                                "unable to transfer data from slave net '{}' with ID {} to master net '{}' with ID {}.",
+                                slave_net->get_name(),
+                                slave_net->get_id(),
+                                master_net->get_name(),
+                                master_net->get_id());
+                }
+            }
+
+            // update module ports
+            if (const auto it = m_module_port_by_net.find(slave_net); it != m_module_port_by_net.end())
+            {
+                for (auto [module, index] : it->second)
+                {
+                    std::get<1>(m_module_ports.at(module).at(index)) = master_net;
+                }
+                m_module_port_by_net[master_net].insert(m_module_port_by_net[master_net].end(), it->second.begin(), it->second.end());
+                m_module_port_by_net.erase(it);
+            }
+
+            m_netlist->delete_net(slave_net);
+            m_net_by_name.erase(slave);
+            merged_nets[slave] = master;
         }
 
         // add global GND gate if required by any instance
@@ -1377,7 +1409,7 @@ namespace hal
             std::unordered_set<Net*> input_nets  = module->get_input_nets();
             std::unordered_set<Net*> output_nets = module->get_output_nets();
 
-            for (const auto& [port_name, port_direction, port_net] : ports)
+            for (const auto& [port_name, port_net] : ports)
             {
                 if (!module->is_input_net(port_net) && !module->is_output_net(port_net))
                 {
@@ -1443,7 +1475,7 @@ namespace hal
             }
         }
 
-        // assign module port names and attributes
+        // assign module port names
         for (const auto& port : verilog_module->m_ports)
         {
             for (const auto& expanded_port_identifier : port->m_expanded_identifiers)
@@ -1451,24 +1483,8 @@ namespace hal
                 if (const auto it = parent_module_assignments.find(expanded_port_identifier); it != parent_module_assignments.end())
                 {
                     Net* port_net = m_net_by_name.at(it->second);
-                    m_module_ports[module].push_back(std::make_tuple(expanded_port_identifier, port->m_direction, port_net));
+                    m_module_ports[module].push_back(std::make_tuple(expanded_port_identifier, port_net));
                     m_module_port_by_net[port_net].push_back(std::make_pair(module, m_module_ports[module].size() - 1));
-
-                    // assign port attributes
-                    for (const VerilogDataEntry& attribute : port->m_attributes)
-                    {
-                        if (!port_net->set_data("attribute", attribute.m_name, attribute.m_type, attribute.m_value))
-                        {
-                            log_warning("verilog_parser",
-                                        "could not set attribute '{} = {}' of type '{}' for port '{}' of instance '{}' of type '{}'.",
-                                        attribute.m_name,
-                                        attribute.m_value,
-                                        attribute.m_type,
-                                        expanded_port_identifier,
-                                        instance_identifier,
-                                        instance_type);
-                        }
-                    }
                 }
             }
         }
@@ -1512,11 +1528,7 @@ namespace hal
             std::string a = left_expanded_signal;
             std::string b = right_expanded_signal;
 
-            if (const auto parent_it = parent_module_assignments.find(a); parent_it != parent_module_assignments.end())
-            {
-                a = parent_it->second;
-            }
-            else if (const auto alias_it = signal_alias.find(a); alias_it != signal_alias.end())
+            if (const auto alias_it = signal_alias.find(a); alias_it != signal_alias.end())
             {
                 a = alias_it->second;
             }
@@ -1525,24 +1537,40 @@ namespace hal
                 return ERR("could not create instance '" + instance_identifier + "' of type '" + instance_type + "': failed to find alias for net '" + a + "'");
             }
 
-            if (const auto parent_it = parent_module_assignments.find(b); parent_it != parent_module_assignments.end())
-            {
-                b = parent_it->second;
-            }
-            else if (const auto alias_it = signal_alias.find(b); alias_it != signal_alias.end())
+            if (const auto alias_it = signal_alias.find(b); alias_it != signal_alias.end())
             {
                 b = alias_it->second;
+            }
+            else if (b == "'0'" || b == "'1'")
+            {
+                // '0' or '1' is assigned, make sure that '0' or '1' net does not get deleted by merging
+                const auto tmp = a;
+                a              = b;
+                b              = tmp;
             }
             else if (b == "'Z'" || b == "'X'")
             {
                 continue;
             }
-            else if (b != "'0'" && b != "'1'")
+            else
             {
                 return ERR("could not create instance '" + instance_identifier + "' of type '" + instance_type + "': failed to find alias for net '" + b + "'");
             }
 
-            m_nets_to_merge[b].push_back(a);
+            m_nets_to_merge.push_back(std::make_pair(a, b));
+        }
+
+        // schedule assigned port nets for merging
+        for (const auto& [port_expression, net_name] : parent_module_assignments)
+        {
+            if (const auto alias_it = signal_alias.find(port_expression); alias_it != signal_alias.end())
+            {
+                m_nets_to_merge.push_back(std::make_pair(net_name, alias_it->second));
+            }
+            else
+            {
+                return ERR("could not create instance '" + instance_identifier + "' of type '" + instance_type + "': failed to find alias for net '" + port_expression + "'");
+            }
         }
 
         // process instances i.e. gates or other entities
@@ -1560,32 +1588,21 @@ namespace hal
                 // expand port assignments
                 for (const auto& [port, assignment] : instance->m_expanded_port_assignments)
                 {
-                    if (const auto it = parent_module_assignments.find(assignment); it != parent_module_assignments.end())
+                    if (const auto alias_it = signal_alias.find(assignment); alias_it != signal_alias.end())
                     {
-                        instance_assignments[port] = it->second;
+                        instance_assignments[port] = alias_it->second;
+                    }
+                    else if (assignment == "'0'" || assignment == "'1'")
+                    {
+                        instance_assignments[port] = assignment;
+                    }
+                    else if (assignment == "'Z'" || assignment == "'X'" || assignment.empty())
+                    {
+                        continue;
                     }
                     else
                     {
-                        if (const auto alias_it = signal_alias.find(assignment); alias_it != signal_alias.end())
-                        {
-                            instance_assignments[port] = alias_it->second;
-                        }
-                        else if (assignment == "'0'" || assignment == "'1'")
-                        {
-                            instance_assignments[port] = assignment;
-                        }
-                        else if (assignment == "'Z'" || assignment == "'X'" || assignment.empty())
-                        {
-                            continue;
-                        }
-                        else if (verilog_module->m_expanded_port_expressions.find(assignment) != verilog_module->m_expanded_port_expressions.end())
-                        {
-                            continue;
-                        }
-                        else
-                        {
-                            return ERR("could not create instance '" + instance_identifier + "' of type '" + instance_type + "': port assignment '" + port + " = " + assignment + "' is invalid");
-                        }
+                        return ERR("could not create instance '" + instance_identifier + "' of type '" + instance_type + "': port assignment '" + port + " = " + assignment + "' is invalid");
                     }
                 }
 
@@ -1643,11 +1660,7 @@ namespace hal
                 {
                     std::string signal;
 
-                    if (const auto parent_it = parent_module_assignments.find(assignment); parent_it != parent_module_assignments.end())
-                    {
-                        signal = parent_it->second;
-                    }
-                    else if (const auto alias_it = signal_alias.find(assignment); alias_it != signal_alias.end())
+                    if (const auto alias_it = signal_alias.find(assignment); alias_it != signal_alias.end())
                     {
                         signal = alias_it->second;
                     }
@@ -1656,10 +1669,6 @@ namespace hal
                         signal = assignment;
                     }
                     else if (assignment == "'Z'" || assignment == "'X'")
-                    {
-                        continue;
-                    }
-                    else if (verilog_module->m_expanded_port_expressions.find(assignment) != verilog_module->m_expanded_port_expressions.end())
                     {
                         continue;
                     }

--- a/plugins/vhdl_parser/include/vhdl_parser/vhdl_parser.h
+++ b/plugins/vhdl_parser/include/vhdl_parser/vhdl_parser.h
@@ -96,7 +96,6 @@ namespace hal
             ci_string m_identifier;
             PinDirection m_direction;
             std::vector<std::vector<u32>> m_ranges;
-            std::vector<VhdlDataEntry> m_attributes;
             std::vector<ci_string> m_expanded_identifiers;
         };
 
@@ -209,7 +208,7 @@ namespace hal
         Net* m_zero_net;
         Net* m_one_net;
         std::unordered_map<ci_string, Net*> m_net_by_name;
-        std::unordered_map<ci_string, std::vector<ci_string>> m_nets_to_merge;
+        std::vector<std::pair<ci_string, ci_string>> m_nets_to_merge;
 
         // parse HDL into intermediate format
         void tokenize();

--- a/plugins/vhdl_parser/src/vhdl_parser.cpp
+++ b/plugins/vhdl_parser/src/vhdl_parser.cpp
@@ -689,6 +689,18 @@ namespace hal
                 port->m_ranges                                         = ranges;
                 vhdl_entity->m_ports_by_identifier[port->m_identifier] = port.get();
                 vhdl_entity->m_ports.push_back(std::move(port));
+
+                if (vhdl_entity->m_signals_by_name.find(port_name) == vhdl_entity->m_signals_by_name.end())
+                {
+                    auto signal    = std::make_unique<VhdlSignal>();
+                    signal->m_name = port_name;
+                    if (!ranges.empty())
+                    {
+                        signal->m_ranges = ranges;
+                    }
+                    vhdl_entity->m_signals_by_name[port_name] = signal.get();
+                    vhdl_entity->m_signals.push_back(std::move(signal));
+                }
             }
         }
 
@@ -881,11 +893,14 @@ namespace hal
 
         for (const auto& signal_name : signal_names)
         {
-            auto signal                                 = std::make_unique<VhdlSignal>();
-            signal->m_name                              = signal_name;
-            signal->m_ranges                            = ranges;
-            vhdl_entity->m_signals_by_name[signal_name] = signal.get();
-            vhdl_entity->m_signals.push_back(std::move(signal));
+            if (vhdl_entity->m_signals_by_name.find(signal_name) == vhdl_entity->m_signals_by_name.end())
+            {
+                auto signal                                 = std::make_unique<VhdlSignal>();
+                signal->m_name                              = signal_name;
+                signal->m_ranges                            = ranges;
+                vhdl_entity->m_signals_by_name[signal_name] = signal.get();
+                vhdl_entity->m_signals.push_back(std::move(signal));
+            }
         }
 
         return OK({});
@@ -1236,10 +1251,6 @@ namespace hal
                     {
                         signal_it->second->m_attributes.push_back(attribute);
                     }
-                    else if (const auto port_it = vhdl_entity->m_ports_by_identifier.find(target); port_it != vhdl_entity->m_ports_by_identifier.end())
-                    {
-                        port_it->second->m_attributes.push_back(attribute);
-                    }
                     else
                     {
                         return ERR("could not assign attributes: invalid attribute target '" + core_strings::to<std::string>(target) + "' within entity '"
@@ -1266,15 +1277,6 @@ namespace hal
         // preparations for alias: count the occurences of all names
         std::queue<VhdlEntity*> q;
         q.push(top_entity);
-
-        // global input/output signals will be named after ports, so take into account for aliases
-        for (const auto& port : top_entity->m_ports)
-        {
-            for (const auto& expanded_port_identifier : port->m_expanded_identifiers)
-            {
-                m_signal_name_occurrences[expanded_port_identifier]++;
-            }
-        }
 
         while (!q.empty())
         {
@@ -1416,22 +1418,24 @@ namespace hal
         {
             for (const auto& expanded_port_identifier : port->m_expanded_identifiers)
             {
-                Net* global_port_net = m_netlist->create_net(core_strings::to<std::string>(expanded_port_identifier));
+                const auto signal_name = get_unique_alias(m_signal_name_occurrences, expanded_port_identifier);
+
+                Net* global_port_net = m_netlist->create_net(core_strings::to<std::string>(signal_name));
                 if (global_port_net == nullptr)
                 {
-                    return ERR("could not construct netlist: failed to create global I/O net '" + core_strings::to<std::string>(expanded_port_identifier) + "'");
+                    return ERR("could not construct netlist: failed to create global I/O net '" + core_strings::to<std::string>(signal_name) + "'");
                 }
 
-                m_net_by_name[expanded_port_identifier] = global_port_net;
+                m_net_by_name[signal_name] = global_port_net;
 
                 // assign global port nets to ports of top module
-                top_assignments[expanded_port_identifier] = expanded_port_identifier;
+                top_assignments[signal_name] = signal_name;
 
                 if (port->m_direction == PinDirection::input || port->m_direction == PinDirection::inout)
                 {
                     if (!global_port_net->mark_global_input_net())
                     {
-                        return ERR("could not construct netlist: failed to mark global I/O net '" + core_strings::to<std::string>(expanded_port_identifier) + "' as global input");
+                        return ERR("could not construct netlist: failed to mark global I/O net '" + core_strings::to<std::string>(signal_name) + "' as global input");
                     }
                 }
 
@@ -1439,7 +1443,7 @@ namespace hal
                 {
                     if (!global_port_net->mark_global_output_net())
                     {
-                        return ERR("could not construct netlist: failed to mark global I/O net '" + core_strings::to<std::string>(expanded_port_identifier) + "' as global output");
+                        return ERR("could not construct netlist: failed to mark global I/O net '" + core_strings::to<std::string>(signal_name) + "' as global output");
                     }
                 }
             }
@@ -1451,124 +1455,122 @@ namespace hal
         }
 
         // merge nets without gates in between them
-        while (!m_nets_to_merge.empty())
+        std::unordered_map<ci_string, ci_string> merged_nets;
+
+        for (auto& [master, slave] : m_nets_to_merge)
         {
-            // master = net that other nets are merged into
-            // slave = net to merge into master and then delete
-            bool progress_made = false;
-
-            for (const auto& [master, merge_set] : m_nets_to_merge)
+            // check if master net has already been merged into other net
+            while (true)
             {
-                // check if none of the slaves is itself a master
-                bool is_master = false;
-                for (const auto& slave : merge_set)
+                if (const auto master_it = merged_nets.find(master); master_it != merged_nets.end())
                 {
-                    if (m_nets_to_merge.find(slave) != m_nets_to_merge.end())
-                    {
-                        is_master = true;
-                        break;
-                    }
+                    master = master_it->second;
                 }
-
-                if (is_master)
+                else
                 {
-                    continue;
+                    break;
                 }
-
-                auto master_net = m_net_by_name.at(master);
-                for (const auto& slave : merge_set)
-                {
-                    auto slave_net = m_net_by_name.at(slave);
-
-                    // merge sources
-                    if (slave_net->is_global_input_net())
-                    {
-                        master_net->mark_global_input_net();
-                    }
-
-                    for (auto src : slave_net->get_sources())
-                    {
-                        Gate* src_gate   = src->get_gate();
-                        GatePin* src_pin = src->get_pin();
-
-                        if (!slave_net->remove_source(src))
-                        {
-                            return ERR("could not construct netlist: unable to remove source from net '" + slave_net->get_name() + "' with ID " + std::to_string(slave_net->get_id()));
-                        }
-
-                        if (!master_net->is_a_source(src_gate, src_pin))
-                        {
-                            if (!master_net->add_source(src_gate, src_pin))
-                            {
-                                return ERR("could not construct netlist: unable to add source to net '" + master_net->get_name() + "' with ID " + std::to_string(master_net->get_id()));
-                            }
-                        }
-                    }
-
-                    // merge destinations
-                    if (slave_net->is_global_output_net())
-                    {
-                        master_net->mark_global_output_net();
-                    }
-
-                    for (auto dst : slave_net->get_destinations())
-                    {
-                        Gate* dst_gate   = dst->get_gate();
-                        GatePin* dst_pin = dst->get_pin();
-
-                        if (!slave_net->remove_destination(dst))
-                        {
-                            return ERR("could not construct netlist: unable to remove destination from net '" + slave_net->get_name() + "' with ID " + std::to_string(slave_net->get_id()));
-                        }
-
-                        if (!master_net->is_a_destination(dst_gate, dst_pin))
-                        {
-                            if (!master_net->add_destination(dst_gate, dst_pin))
-                            {
-                                return ERR("could not construct netlist: unable to add destination to net '" + master_net->get_name() + "' with ID " + std::to_string(master_net->get_id()));
-                            }
-                        }
-                    }
-
-                    // merge generics and attributes
-                    for (const auto& it : slave_net->get_data_map())
-                    {
-                        if (!master_net->set_data(std::get<0>(it.first), std::get<1>(it.first), std::get<0>(it.second), std::get<1>(it.second)))
-                        {
-                            log_warning("vhdl_parser",
-                                        "unable to transfer data from slave net '{}' with ID {} to master net '{}' with ID {}.",
-                                        slave_net->get_name(),
-                                        slave_net->get_id(),
-                                        master_net->get_name(),
-                                        master_net->get_id());
-                        }
-                    }
-
-                    // update module ports
-                    if (const auto it = m_module_port_by_net.find(slave_net); it != m_module_port_by_net.end())
-                    {
-                        for (auto [module, index] : it->second)
-                        {
-                            std::get<1>(m_module_ports.at(module).at(index)) = master_net;
-                        }
-                        m_module_port_by_net[master_net].insert(m_module_port_by_net[master_net].end(), it->second.begin(), it->second.end());
-                        m_module_port_by_net.erase(it);
-                    }
-
-                    // make sure to keep module ports up to date
-                    m_netlist->delete_net(slave_net);
-                    m_net_by_name.erase(slave);
-                }
-
-                m_nets_to_merge.erase(master);
-                progress_made = true;
-                break;
             }
 
-            if (!progress_made)
+            // check if slave net has already been merged into other net
+            while (true)
             {
-                return ERR("could not construct netlist: cyclic dependency between signals detected");
+                if (const auto slave_it = merged_nets.find(slave); slave_it != merged_nets.end())
+                {
+                    slave = slave_it->second;
+                }
+                else
+                {
+                    break;
+                }
             }
+
+            auto master_net = m_net_by_name.at(master);
+            auto slave_net  = m_net_by_name.at(slave);
+
+            if (master_net == slave_net)
+            {
+                continue;
+            }
+
+            // merge sources
+            if (slave_net->is_global_input_net())
+            {
+                master_net->mark_global_input_net();
+            }
+
+            for (auto src : slave_net->get_sources())
+            {
+                Gate* src_gate   = src->get_gate();
+                GatePin* src_pin = src->get_pin();
+
+                if (!slave_net->remove_source(src))
+                {
+                    return ERR("could not construct netlist: failed to remove source from net '" + slave_net->get_name() + "' with ID " + std::to_string(slave_net->get_id()));
+                }
+
+                if (!master_net->is_a_source(src_gate, src_pin))
+                {
+                    if (!master_net->add_source(src_gate, src_pin))
+                    {
+                        return ERR("could not construct netlist: failed to add source to net '" + master_net->get_name() + "' with ID " + std::to_string(master_net->get_id()));
+                    }
+                }
+            }
+
+            // merge destinations
+            if (slave_net->is_global_output_net())
+            {
+                master_net->mark_global_output_net();
+            }
+
+            for (auto dst : slave_net->get_destinations())
+            {
+                Gate* dst_gate   = dst->get_gate();
+                GatePin* dst_pin = dst->get_pin();
+
+                if (!slave_net->remove_destination(dst))
+                {
+                    return ERR("could not construct netlist: failed to remove destination from net '" + slave_net->get_name() + "' with ID " + std::to_string(slave_net->get_id()));
+                }
+
+                if (!master_net->is_a_destination(dst_gate, dst_pin))
+                {
+                    if (!master_net->add_destination(dst_gate, dst_pin))
+                    {
+                        return ERR("could not construct netlist: failed to add destination to net '" + master_net->get_name() + "' with ID " + std::to_string(master_net->get_id()));
+                    }
+                }
+            }
+
+            // merge generics and attributes
+            for (const auto& [identifier, content] : slave_net->get_data_map())
+            {
+                if (!master_net->set_data(std::get<0>(identifier), std::get<1>(identifier), std::get<0>(content), std::get<1>(content)))
+                {
+                    log_warning("vhdl_parser",
+                                "unable to transfer data from slave net '{}' with ID {} to master net '{}' with ID {}.",
+                                slave_net->get_name(),
+                                slave_net->get_id(),
+                                master_net->get_name(),
+                                master_net->get_id());
+                }
+            }
+
+            // update module ports
+            if (const auto it = m_module_port_by_net.find(slave_net); it != m_module_port_by_net.end())
+            {
+                for (auto [module, index] : it->second)
+                {
+                    std::get<1>(m_module_ports.at(module).at(index)) = master_net;
+                }
+                m_module_port_by_net[master_net].insert(m_module_port_by_net[master_net].end(), it->second.begin(), it->second.end());
+                m_module_port_by_net.erase(it);
+            }
+
+            m_netlist->delete_net(slave_net);
+            m_net_by_name.erase(slave);
+            merged_nets[slave] = master;
         }
 
         // update module nets, internal nets, input nets, and output nets
@@ -1672,7 +1674,7 @@ namespace hal
             }
         }
 
-        // assign module port names and attributes
+        // assign module port names
         for (const auto& port : vhdl_entity->m_ports)
         {
             for (const auto& expanded_port_identifier : port->m_expanded_identifiers)
@@ -1682,22 +1684,6 @@ namespace hal
                     Net* port_net = m_net_by_name.at(it->second);
                     m_module_ports[module].push_back(std::make_pair(core_strings::to<std::string>(expanded_port_identifier), port_net));
                     m_module_port_by_net[port_net].push_back(std::make_pair(module, m_module_ports[module].size() - 1));
-
-                    // assign port attributes
-                    for (const VhdlDataEntry& attribute : port->m_attributes)
-                    {
-                        if (!port_net->set_data("attribute", attribute.m_name, attribute.m_type, attribute.m_value))
-                        {
-                            log_warning("vhdl_parser",
-                                        "could not set attribute '{} = {}' of type '{}' for port '{}' of instance '{}' of type '{}'.",
-                                        attribute.m_name,
-                                        attribute.m_value,
-                                        attribute.m_type,
-                                        expanded_port_identifier,
-                                        instance_identifier,
-                                        instance_type);
-                        }
-                    }
                 }
             }
         }
@@ -1742,11 +1728,7 @@ namespace hal
             ci_string a = left_expanded_signal;
             ci_string b = right_expanded_signal;
 
-            if (const auto parent_it = parent_module_assignments.find(a); parent_it != parent_module_assignments.end())
-            {
-                a = parent_it->second;
-            }
-            else if (const auto alias_it = signal_alias.find(a); alias_it != signal_alias.end())
+            if (const auto alias_it = signal_alias.find(a); alias_it != signal_alias.end())
             {
                 a = alias_it->second;
             }
@@ -1756,25 +1738,42 @@ namespace hal
                            + "': failed to find alias for net '" + core_strings::to<std::string>(a) + "'");
             }
 
-            if (const auto parent_it = parent_module_assignments.find(b); parent_it != parent_module_assignments.end())
-            {
-                b = parent_it->second;
-            }
-            else if (const auto alias_it = signal_alias.find(b); alias_it != signal_alias.end())
+            if (const auto alias_it = signal_alias.find(b); alias_it != signal_alias.end())
             {
                 b = alias_it->second;
+            }
+            else if (b == "'0'" || b == "'1'")
+            {
+                // '0' or '1' is assigned, make sure that '0' or '1' net does not get deleted by merging
+                const auto tmp = a;
+                a              = b;
+                b              = tmp;
             }
             else if (b == "'Z'" || b == "'X'")
             {
                 continue;
             }
-            else if (b != "'0'" && b != "'1'")
+            else
             {
                 return ERR("could not create instance '" + core_strings::to<std::string>(instance_identifier) + "' of type '" + core_strings::to<std::string>(instance_type)
                            + "': failed to find alias for net '" + core_strings::to<std::string>(b) + "'");
             }
 
-            m_nets_to_merge[b].push_back(a);
+            m_nets_to_merge.push_back(std::make_pair(a, b));
+        }
+
+        // schedule assigned port nets for merging
+        for (const auto& [port_expression, net_name] : parent_module_assignments)
+        {
+            if (const auto alias_it = signal_alias.find(port_expression); alias_it != signal_alias.end())
+            {
+                m_nets_to_merge.push_back(std::make_pair(net_name, alias_it->second));
+            }
+            else
+            {
+                return ERR("could not create instance '" + core_strings::to<std::string>(instance_identifier) + "' of type '" + core_strings::to<std::string>(instance_type)
+                           + "': failed to find alias for net '" + core_strings::to<std::string>(port_expression) + "'");
+            }
         }
 
         // process instances i.e. gates or other entities
@@ -1792,11 +1791,7 @@ namespace hal
                 // expand port assignments
                 for (const auto& [port, assignment] : instance->m_expanded_port_assignments)
                 {
-                    if (const auto it = parent_module_assignments.find(assignment); it != parent_module_assignments.end())
-                    {
-                        instance_assignments[port] = it->second;
-                    }
-                    else if (const auto alias_it = signal_alias.find(assignment); alias_it != signal_alias.end())
+                    if (const auto alias_it = signal_alias.find(assignment); alias_it != signal_alias.end())
                     {
                         instance_assignments[port] = alias_it->second;
                     }
@@ -1805,10 +1800,6 @@ namespace hal
                         instance_assignments[port] = assignment;
                     }
                     else if (assignment == "'Z'" || assignment == "'X'" || assignment == "")
-                    {
-                        continue;
-                    }
-                    else if (vhdl_entity->m_expanded_port_identifiers.find(assignment) != vhdl_entity->m_expanded_port_identifiers.end())
                     {
                         continue;
                     }
@@ -1875,11 +1866,7 @@ namespace hal
                 {
                     ci_string signal;
 
-                    if (const auto parent_it = parent_module_assignments.find(assignment); parent_it != parent_module_assignments.end())
-                    {
-                        signal = parent_it->second;
-                    }
-                    else if (const auto alias_it = signal_alias.find(assignment); alias_it != signal_alias.end())
+                    if (const auto alias_it = signal_alias.find(assignment); alias_it != signal_alias.end())
                     {
                         signal = alias_it->second;
                     }
@@ -1888,10 +1875,6 @@ namespace hal
                         signal = assignment;
                     }
                     else if (assignment == "'Z'" || assignment == "'X'" || assignment == "")
-                    {
-                        continue;
-                    }
-                    else if (vhdl_entity->m_expanded_port_identifiers.find(assignment) != vhdl_entity->m_expanded_port_identifiers.end())
                     {
                         continue;
                     }

--- a/plugins/vhdl_parser/test/vhdl_parser.cpp
+++ b/plugins/vhdl_parser/test/vhdl_parser.cpp
@@ -1783,13 +1783,13 @@ namespace hal {
                                         "  port ( "
                                         "    net_global_in : in STD_LOGIC := 'X'; "
                                         "    net_global_out : out STD_LOGIC := 'X'; "
-                                        "    net_slave_1: in STD_LOGIC := 'X'; "
+                                        "    net_master: in STD_LOGIC := 'X'; "
                                         "  ); "
                                         "end TEST_Comp; "
                                         "architecture STRUCTURE of TEST_Comp is "
                                         "  signal net_slave_0 : STD_LOGIC; "
                                         "  signal net_slave_2 : STD_LOGIC; "
-                                        "  signal net_master : STD_LOGIC; "
+                                        "  signal net_slave_1 : STD_LOGIC; "
                                         "  attribute slave_0_attr : string; "    // <- signal attributes are vhdl specific
                                         "  attribute slave_0_attr of net_slave_0 : signal is \"slave_0_attr\"; "
                                         "  attribute slave_1_attr : string; "
@@ -1800,8 +1800,8 @@ namespace hal {
                                         "  attribute master_attr of net_master : signal is \"master_attr\"; "
                                         "begin "
                                         "  net_slave_1 <= net_slave_0;  "
-                                        "  net_slave_0 <= net_master; "
                                         "  net_slave_2 <= net_slave_0; "
+                                        "  net_master <= net_slave_0; "
                                         "  gate_0 : BUF "
                                         "    port map ( "
                                         "      I => net_global_in, "
@@ -1853,6 +1853,44 @@ namespace hal {
                           std::make_tuple("string", "slave_2_attr"));
             }
             {
+                // Create a cyclic master-slave Net hierarchy (first master net should survive)
+                NO_COUT_TEST_BLOCK;
+                std::string netlist_input("-- Device\t: device_name\n"
+                                        "entity TEST_Comp is "
+                                        "  port ( "
+                                        "    net_global_in : in STD_LOGIC := 'X'; "
+                                        "    net_global_out : out STD_LOGIC := 'X'; "
+                                        "  ); "
+                                        "end TEST_Comp; "
+                                        "architecture STRUCTURE of TEST_Comp is "
+                                        "  signal net_0 : STD_LOGIC; "
+                                        "  signal net_1 : STD_LOGIC; "
+                                        "begin "
+                                        "  net_0 <= net_1;  "
+                                        "  net_1 <= net_0; "
+                                        "  gate_0 : BUF "
+                                        "    port map ( "
+                                        "      I => net_global_in, "
+                                        "      O => net_0 "
+                                        "    ); "
+                                        "  gate_1 : BUF "
+                                        "    port map ( "
+                                        "      I => net_1, "
+                                        "      O => net_global_out "
+                                        "    ); "
+                                        "end STRUCTURE;");
+                const GateLibrary* gate_lib = test_utils::get_gate_library();
+                std::filesystem::path vhdl_file = test_utils::create_sandbox_file("netlist.v", netlist_input);
+                VHDLParser vhdl_parser;
+                auto nl_res = vhdl_parser.parse_and_instantiate(vhdl_file, gate_lib);
+                ASSERT_TRUE(nl_res.is_ok());
+                std::unique_ptr<Netlist> nl = nl_res.get();
+                
+                ASSERT_NE(nl, nullptr);
+                EXPECT_EQ(nl->get_nets().size(), 3);    // global_in + global_out + net_0
+                EXPECT_EQ(nl->get_nets(test_utils::net_name_filter("net_0")).size(), 1);
+            }
+            {
                 //Testing the assignment of logic vectors
                 std::string netlist_input("-- Device\t: device_name\n"
                                         "entity TEST_Comp is "
@@ -1865,7 +1903,7 @@ namespace hal {
                                         "  signal net_slave : STD_LOGIC_VECTOR ( 0 to 3 ); "
                                         "  signal net_master : STD_LOGIC_VECTOR ( 0 to 3 ); "
                                         "begin "
-                                        "  net_slave <= net_master; "
+                                        "  net_master <= net_slave; "
                                         "  gate_0 : BUF "
                                         "    port map ( "
                                         "      I => net_global_in, "
@@ -2385,7 +2423,7 @@ namespace hal {
                 std::filesystem::path vhdl_file = test_utils::create_sandbox_file("netlist.v", netlist_input);
                 VHDLParser vhdl_parser;
                 auto nl_res = vhdl_parser.parse_and_instantiate(vhdl_file, gate_lib);
-                ASSERT_TRUE(nl_res.is_error());
+                EXPECT_TRUE(nl_res.is_error());
             }
             {
                 // Use an unknown Gate type (not in Gate library)
@@ -2409,7 +2447,7 @@ namespace hal {
                 std::filesystem::path vhdl_file = test_utils::create_sandbox_file("netlist.v", netlist_input);
                 VHDLParser vhdl_parser;
                 auto nl_res = vhdl_parser.parse_and_instantiate(vhdl_file, gate_lib);
-                ASSERT_TRUE(nl_res.is_error());
+                EXPECT_TRUE(nl_res.is_error());
             }
             {
                 // The input does not contain any entity (is empty)
@@ -2419,7 +2457,7 @@ namespace hal {
                 std::filesystem::path vhdl_file = test_utils::create_sandbox_file("netlist.v", netlist_input);
                 VHDLParser vhdl_parser;
                 auto nl_res = vhdl_parser.parse_and_instantiate(vhdl_file, gate_lib);
-                ASSERT_TRUE(nl_res.is_error());
+                EXPECT_TRUE(nl_res.is_error());
             }
         /* non-used entity _WILL_ create problems (erroneously considered as top module)
             {
@@ -2464,39 +2502,6 @@ namespace hal {
                 EXPECT_NE(nl, nullptr);
             }
             */
-            {
-                // Create a cyclic master-slave Net hierarchy
-                NO_COUT_TEST_BLOCK;
-                std::string netlist_input("-- Device\t: device_name\n"
-                                        "entity TEST_Comp is "
-                                        "  port ( "
-                                        "    net_global_in : in STD_LOGIC := 'X'; "
-                                        "    net_global_out : out STD_LOGIC := 'X'; "
-                                        "  ); "
-                                        "end TEST_Comp; "
-                                        "architecture STRUCTURE of TEST_Comp is "
-                                        "  signal net_0 : STD_LOGIC; "
-                                        "  signal net_1 : STD_LOGIC; "
-                                        "begin "
-                                        "  net_0 <= net_1;  "
-                                        "  net_1 <= net_0; "
-                                        "  gate_0 : BUF "
-                                        "    port map ( "
-                                        "      I => net_global_in, "
-                                        "      O => net_0 "
-                                        "    ); "
-                                        "  gate_1 : BUF "
-                                        "    port map ( "
-                                        "      I => net_1, "
-                                        "      O => net_global_out "
-                                        "    ); "
-                                        "end STRUCTURE;");
-                const GateLibrary* gate_lib = test_utils::get_gate_library();
-                std::filesystem::path vhdl_file = test_utils::create_sandbox_file("netlist.v", netlist_input);
-                VHDLParser vhdl_parser;
-                auto nl_res = vhdl_parser.parse_and_instantiate(vhdl_file, gate_lib);
-                ASSERT_TRUE(nl_res.is_error());
-            }
             if(test_utils::known_issue_tests_active())
             {
                 // Use non-numeric ranges (invalid) (ISSUE: stoi failure l.827)
@@ -2517,7 +2522,7 @@ namespace hal {
                 std::filesystem::path vhdl_file = test_utils::create_sandbox_file("netlist.v", netlist_input);
                 VHDLParser vhdl_parser;
                 auto nl_res = vhdl_parser.parse_and_instantiate(vhdl_file, gate_lib);
-                ASSERT_TRUE(nl_res.is_error());
+                EXPECT_TRUE(nl_res.is_error());
             }
             // ------ VHDL specific tests ------
             {
@@ -2540,7 +2545,7 @@ namespace hal {
                 std::filesystem::path vhdl_file = test_utils::create_sandbox_file("netlist.v", netlist_input);
                 VHDLParser vhdl_parser;
                 auto nl_res = vhdl_parser.parse_and_instantiate(vhdl_file, gate_lib);
-                ASSERT_TRUE(nl_res.is_error());
+                EXPECT_TRUE(nl_res.is_error());
             }
             {
                 // The architecture contains an invalid keyword (neither 'signal' nor 'attribute')
@@ -2563,7 +2568,7 @@ namespace hal {
                 std::filesystem::path vhdl_file = test_utils::create_sandbox_file("netlist.v", netlist_input);
                 VHDLParser vhdl_parser;
                 auto nl_res = vhdl_parser.parse_and_instantiate(vhdl_file, gate_lib);
-                ASSERT_TRUE(nl_res.is_error());
+                EXPECT_TRUE(nl_res.is_error());
             }
             {
                 // Testing incorrect data_types in the "generic map" block
@@ -2588,7 +2593,7 @@ namespace hal {
                 std::filesystem::path vhdl_file = test_utils::create_sandbox_file("netlist.v", netlist_input);
                 VHDLParser vhdl_parser;
                 auto nl_res = vhdl_parser.parse_and_instantiate(vhdl_file, gate_lib);
-                ASSERT_TRUE(nl_res.is_error());
+                EXPECT_TRUE(nl_res.is_error());
             }
             {
                 // Leave the 'port map' block empty (Gate is not connected)
@@ -2671,7 +2676,7 @@ namespace hal {
                 std::filesystem::path vhdl_file = test_utils::create_sandbox_file("netlist.v", netlist_input);
                 VHDLParser vhdl_parser;
                 auto nl_res = vhdl_parser.parse_and_instantiate(vhdl_file, gate_lib);
-                ASSERT_TRUE(nl_res.is_error());
+                EXPECT_TRUE(nl_res.is_error());
             }
             {
                 // The amount of bounds does not match with the vector dimension (vhdl specific)
@@ -2694,11 +2699,7 @@ namespace hal {
                 std::filesystem::path vhdl_file = test_utils::create_sandbox_file("netlist.v", netlist_input);
                 VHDLParser vhdl_parser;
                 auto nl_res = vhdl_parser.parse_and_instantiate(vhdl_file, gate_lib);
-                ASSERT_TRUE(nl_res.is_error());
-                // std::unique_ptr<Netlist> nl = nl_res.get();
-                // if (nl != nullptr) {
-                //     EXPECT_EQ(nl->get_nets().size(), 1);
-                // }
+                EXPECT_TRUE(nl_res.is_error());
             }
             {
                 // The ranges of the pin vectors do not match in size
@@ -2719,7 +2720,7 @@ namespace hal {
                 std::filesystem::path vhdl_file = test_utils::create_sandbox_file("netlist.v", netlist_input);
                 VHDLParser vhdl_parser;
                 auto nl_res = vhdl_parser.parse_and_instantiate(vhdl_file, gate_lib);
-                ASSERT_TRUE(nl_res.is_error());
+                EXPECT_TRUE(nl_res.is_error());
             }
             {
                 // The right side of a pin assignment does no match any vector format
@@ -2740,7 +2741,7 @@ namespace hal {
                 std::filesystem::path vhdl_file = test_utils::create_sandbox_file("netlist.v", netlist_input);
                 VHDLParser vhdl_parser;
                 auto nl_res = vhdl_parser.parse_and_instantiate(vhdl_file, gate_lib);
-                ASSERT_TRUE(nl_res.is_error());
+                EXPECT_TRUE(nl_res.is_error());
             }
         TEST_END
     }


### PR DESCRIPTION
- all module/entity ports are now implicitly created as signals as well (fixes a bug related to unconnected ports which are directly assigned to wires/signals)
- wire/signal assigns are handled different internally (fixes bugs related to multiple subsequent assigns to/of the same wire/signal)