### PR TITLE
Feature/verilog parser port aliasing

### DIFF
--- a/plugins/verilog_parser/include/verilog_parser/verilog_parser.h
+++ b/plugins/verilog_parser/include/verilog_parser/verilog_parser.h
@@ -147,7 +147,7 @@ namespace hal
             std::vector<std::unique_ptr<VerilogPort>> m_ports;
             std::map<std::string, VerilogPort*> m_ports_by_identifier;
             std::map<std::string, VerilogPort*> m_ports_by_expression;
-            std::set<std::string> m_expanded_port_expressions;
+            std::map<std::string, std::string> m_expanded_port_identifiers_to_expressions;
 
             // signals
             std::vector<std::unique_ptr<VerilogSignal>> m_signals;

--- a/plugins/verilog_parser/test/verilog_parser.cpp
+++ b/plugins/verilog_parser/test/verilog_parser.cpp
@@ -817,7 +817,7 @@ namespace hal {
                 const GateLibrary* gl = test_utils::get_gate_library();
 
                 std::string netlist_input("module sub_mod (as, .bs(bs_int), cs);"
-                                          "   input as, bs;"
+                                          "   input as, bs_int;"
                                           "   output cs;"
                                           ""
                                           "   AND2 gate_0 ("


### PR DESCRIPTION
* adds limited support for Verilog module port aliasing, i.e., a port has an external name that is different from the internal one