### PR TITLE
keep track of all parent modules of a module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ All notable changes to this project will be documented in this file.
   * changed behavior of import netlist dialog, suggest only non-existing directory names and loop until an acceptable name was entered
   * changed appearance and behavior of import project dialog, make sure existing hal projects don't get overwritten
   * changed installation script policy to install Python packages (omit 'pip install' which would need virtual environment)
+  * removed `Module::contains_module`, use `Module::is_top_module_of` instead
+  * removed `recursive` parameter from `Module::get_parent_modules`, `Module::is_parent_module_of`, and `Module::is_submodule_of`
 * bugfixes
   * fixed colors in Python Console when switching between color schemes
   * fixed pybind of `Module::get_gates`

--- a/include/hal_core/netlist/module.h
+++ b/include/hal_core/netlist/module.h
@@ -132,9 +132,9 @@ namespace hal
         Grouping* get_grouping() const;
 
         /**
-         * Get the depth of the module within the module hierarchie (0 = top module, 1 = direct child of top module, ...).
+         * Get the depth of the module within the module hierarchy (0 = top module, 1 = direct child of top module, ...).
          * 
-         * @returns The depth within the module hierarchie.
+         * @returns The depth within the module hierarchy.
          */
         int get_submodule_depth() const;
 
@@ -147,15 +147,13 @@ namespace hal
         Module* get_parent_module() const;
 
         /**
-         * Get all parents of this module.<br>
-         * If `recursive` is set to true, all indirect parents are also included.<br>
+         * Get all parents of this module, including all indirect parents.<br>
          * The optional filter is evaluated on every candidate such that the result only contains those matching the specified condition.
          *
          * @param[in] filter - An optional filter.
-         * @param[in] recursive - Set `true` to include indirect parents as well, `false` otherwise.
          * @returns A vector of parent modules.
          */
-        std::vector<Module*> get_parent_modules(const std::function<bool(Module*)>& filter = nullptr, bool recursive = true) const;
+        std::vector<Module*> get_parent_modules(const std::function<bool(Module*)>& filter = nullptr) const;
 
         /**
          * Set a new parent for this module.<br>
@@ -168,12 +166,12 @@ namespace hal
 
         /**
          * Check if the module is a parent of the specified module.
+         * Includes indirect parent modules.
          * 
          * @param[in] module - The module.
-         * @param[in] recursive - Set `true` to check recursively, `false` otherwise.
          * @returns `true` if the module is a parent of the specified module, `false` otherwise.
          */
-        bool is_parent_module_of(const Module* module, bool recursive = false) const;
+        bool is_parent_module_of(const Module* module) const;
 
         /**
          * Get all direct submodules of this module.<br>
@@ -188,22 +186,12 @@ namespace hal
 
         /**
          * Check if the module is a submodule of the specified module.
+         * Includes indirect submodules.
          * 
          * @param[in] module - The module.
-         * @param[in] recursive - Set `true` to check recursively, `false` otherwise.
          * @returns `true` if the module is a submodule of the specified module, `false` otherwise.
          */
-        bool is_submodule_of(const Module* module, bool recursive = false) const;
-
-        /**
-         * Checks whether another module is a submodule of this module.<br>
-         * If \p recursive is set to true, all indirect submodules are also included.
-         *
-         * @param[in] other - Other module to check for.
-         * @param[in] recursive - Set `true` to include indirect submodules as well, `false` otherwise.
-         * @returns `true` if the other module is a submodule, `false` otherwise.
-         */
-        bool contains_module(const Module* other, bool recursive = false) const;
+        bool is_submodule_of(const Module* module) const;
 
         /**
          * Returns true only if the module is the top module of the netlist.
@@ -704,7 +692,7 @@ namespace hal
         /* grouping */
         Grouping* m_grouping = nullptr;
 
-        Module* m_parent;
+        std::list<Module*> m_parents;
         std::unordered_map<u32, Module*> m_submodules_map;
         std::vector<Module*> m_submodules;
 

--- a/include/hal_core/netlist/netlist_internal_manager.h
+++ b/include/hal_core/netlist/netlist_internal_manager.h
@@ -81,6 +81,7 @@ namespace hal
         // module functions
         Module* create_module(u32 id, Module* parent, const std::string& name);
         bool delete_module(Module* module);
+        bool module_set_parent(Module* module, Module* new_parent);
         bool module_assign_gate(Module* m, Gate* g);
         bool module_assign_gates(Module* module, const std::vector<Gate*>& gates);
         bool module_check_net(Module* module, Net* net, bool recursive = false);

--- a/plugins/gui/src/selection_details_widget/module_details_widget/module_info_table.cpp
+++ b/plugins/gui/src/selection_details_widget/module_details_widget/module_info_table.cpp
@@ -1,36 +1,35 @@
 #include "gui/selection_details_widget/module_details_widget/module_info_table.h"
 
-#include "hal_core/netlist/module.h"
-
 #include "gui/gui_globals.h"
+#include "gui/module_dialog/module_dialog.h"
 #include "gui/python/py_code_provider.h"
+#include "gui/user_action/action_add_items_to_object.h"
+#include "gui/user_action/action_create_object.h"
 #include "gui/user_action/action_rename_object.h"
 #include "gui/user_action/action_set_object_type.h"
-#include "gui/user_action/action_create_object.h"
-#include "gui/user_action/action_add_items_to_object.h"
 #include "gui/user_action/user_action_compound.h"
-#include "gui/module_dialog/module_dialog.h"
+#include "hal_core/netlist/module.h"
 
-#include <QMenu>
 #include <QInputDialog>
+#include <QMenu>
 
 namespace hal
 {
-    const QString ModuleInfoTable::nameRowKey = "Name";
-    const QString ModuleInfoTable::idRowKey = "ID";
-    const QString ModuleInfoTable::typeRowKey = "Type";
-    const QString ModuleInfoTable::moduleRowKey = "Parent";
-    const QString ModuleInfoTable::noOfAllGatesRowKey = "Total number of gates";
-    const QString ModuleInfoTable::noOfDirectGatesRowKey = "Number of direct member gates";
+    const QString ModuleInfoTable::nameRowKey                  = "Name";
+    const QString ModuleInfoTable::idRowKey                    = "ID";
+    const QString ModuleInfoTable::typeRowKey                  = "Type";
+    const QString ModuleInfoTable::moduleRowKey                = "Parent";
+    const QString ModuleInfoTable::noOfAllGatesRowKey          = "Total number of gates";
+    const QString ModuleInfoTable::noOfDirectGatesRowKey       = "Number of direct member gates";
     const QString ModuleInfoTable::noOfGatesInSubmodulesRowKey = "Number of gates in submodules";
-    const QString ModuleInfoTable::noOfModulesRowKey = "Number of submodules";
-    const QString ModuleInfoTable::noOfNetsRowKey = "Number of nets";
-    const QString ModuleInfoTable::noOfPinsKey = "Number of pins";
-    const QString ModuleInfoTable::noOfPinGroupsKey = "Number of pin groups";
-    const QString ModuleInfoTable::noOfInputNetsKey = "Number of inputs";
-    const QString ModuleInfoTable::noOfOutputNetsKey = "Number of outputs";
-    const QString ModuleInfoTable::noOfInternalNetsKey = "Number of internal nets";
-    const QString ModuleInfoTable::isTopModuleKey = "Is top module?";
+    const QString ModuleInfoTable::noOfModulesRowKey           = "Number of submodules";
+    const QString ModuleInfoTable::noOfNetsRowKey              = "Number of nets";
+    const QString ModuleInfoTable::noOfPinsKey                 = "Number of pins";
+    const QString ModuleInfoTable::noOfPinGroupsKey            = "Number of pin groups";
+    const QString ModuleInfoTable::noOfInputNetsKey            = "Number of inputs";
+    const QString ModuleInfoTable::noOfOutputNetsKey           = "Number of outputs";
+    const QString ModuleInfoTable::noOfInternalNetsKey         = "Number of internal nets";
+    const QString ModuleInfoTable::isTopModuleKey              = "Is top module?";
 
     ModuleInfoTable::ModuleInfoTable(QWidget* parent) : GeneralTableWidget(parent), mModule(nullptr), mPyIcon(":/icons/python")
     {
@@ -67,7 +66,7 @@ namespace hal
         mNumOfAllGatesContextMenu->addAction(mPyIcon, "Get all gates recursively", std::bind(&ModuleInfoTable::pyCopyAllGates, this));
 
         mNumOfDirectGatesContextMenu = new QMenu();
-        mNumOfDirectGatesContextMenu->addAction("Number of gates to clipboard", std::bind(&ModuleInfoTable::copyNumberOfDirectGates,this));
+        mNumOfDirectGatesContextMenu->addAction("Number of gates to clipboard", std::bind(&ModuleInfoTable::copyNumberOfDirectGates, this));
         mNumOfDirectGatesContextMenu->addAction(mPyIcon, "Get direct member gates", std::bind(&ModuleInfoTable::pyCopyDirectMemberGates, this));
 
         mNumOfGatesInSubmodulesContextMenu = new QMenu();
@@ -89,9 +88,9 @@ namespace hal
         mNumOfPinGroupsContextMenu->addAction("Number of pin groups to clipboard", std::bind(&ModuleInfoTable::copyNumberOfPinGroups, this));
         mNumOfPinGroupsContextMenu->addAction(mPyIcon, "Get pin groups", std::bind(&ModuleInfoTable::pyCopyGetPinGroups, this));
 
-        mNumOfInputNetsContextMenu = new QMenu;//making this widget the parent changes the context menu's background color...
+        mNumOfInputNetsContextMenu = new QMenu;    //making this widget the parent changes the context menu's background color...
         mNumOfInputNetsContextMenu->addAction("Number of input nets to clipboard", std::bind(&ModuleInfoTable::copyNumberOfInputs, this));
-        mNumOfInputNetsContextMenu->addAction(mPyIcon, "Get input nets", std::bind(&ModuleInfoTable::pyCopyGetInputNets,this));
+        mNumOfInputNetsContextMenu->addAction(mPyIcon, "Get input nets", std::bind(&ModuleInfoTable::pyCopyGetInputNets, this));
         mNumOfInputNetsContextMenu->addAction(mPyIcon, "Get input pins", std::bind(&ModuleInfoTable::pyCopyInputPins, this));
 
         mNumOfOutputNetsContextMenu = new QMenu;
@@ -124,7 +123,7 @@ namespace hal
 
     void ModuleInfoTable::setModule(hal::Module* module)
     {
-        if(gNetlist->is_module_in_netlist(module))
+        if (gNetlist->is_module_in_netlist(module))
         {
             mModule = module;
             module->is_top_module() ? mChangeParentAction->setEnabled(false) : mChangeParentAction->setEnabled(true);
@@ -144,7 +143,7 @@ namespace hal
             setRow(noOfOutputNetsKey, numberOfOutputNets(), mNumOfOutputNetsContextMenu);
             setRow(noOfInternalNetsKey, numberOfInternalNets(), mNumOfInternalNetsContextMenu);
             setRow(isTopModuleKey, isTopModule(), mIsTopModuleContextMenu);
-            
+
             adjustSize();
         }
     }
@@ -163,7 +162,7 @@ namespace hal
     {
         QString type = QString::fromStdString(mModule->get_type());
 
-        if(type.isEmpty())
+        if (type.isEmpty())
             type = "None";
 
         return type;
@@ -175,7 +174,7 @@ namespace hal
 
         Module* module = mModule->get_parent_module();
 
-        if(module)
+        if (module)
             parentModule = QString::fromStdString(module->get_name()) + "[ID:" + QString::number(module->get_id()) + "]";
 
         return parentModule;
@@ -184,18 +183,18 @@ namespace hal
     QString ModuleInfoTable::numberOfAllGates() const
     {
         return QString::number(mModule->get_gates(nullptr, true).size());
-//        QString numOfGates = "";
+        //        QString numOfGates = "";
 
-//        int numOfAllChilds = mModule->get_gates(nullptr, true).size();
-//        int numOfDirectChilds = mModule->get_gates(nullptr, false).size();
-//        int numOfChildsInModules = numOfAllChilds - numOfDirectChilds;
+        //        int numOfAllChilds = mModule->get_gates(nullptr, true).size();
+        //        int numOfDirectChilds = mModule->get_gates(nullptr, false).size();
+        //        int numOfChildsInModules = numOfAllChilds - numOfDirectChilds;
 
-//        numOfGates.append(QString::number(numOfAllChilds));
+        //        numOfGates.append(QString::number(numOfAllChilds));
 
-//        if(numOfChildsInModules > 0)
-//            numOfGates.append(" (" + QString::number(numOfDirectChilds) + " direct members and " + QString::number(numOfChildsInModules) +" in submodules)");
+        //        if(numOfChildsInModules > 0)
+        //            numOfGates.append(" (" + QString::number(numOfDirectChilds) + " direct members and " + QString::number(numOfChildsInModules) +" in submodules)");
 
-//        return numOfGates;
+        //        return numOfGates;
     }
 
     QString ModuleInfoTable::numberOfDirectGateMembers() const
@@ -251,7 +250,7 @@ namespace hal
     void ModuleInfoTable::changeName()
     {
         QString oldName = QString::fromStdString(mModule->get_name());
-        QString prompt = "Change module name";
+        QString prompt  = "Change module name";
 
         bool confirm;
         QString newName = QInputDialog::getText(this, prompt, "New name:", QLineEdit::Normal, oldName, &confirm);
@@ -294,7 +293,7 @@ namespace hal
         if (confirm)
         {
             ActionSetObjectType* act = new ActionSetObjectType(newType);
-            act->setObject(UserActionObject(mModule->get_id(),UserActionObjectType::Module));
+            act->setObject(UserActionObject(mModule->get_id(), UserActionObjectType::Module));
             act->exec();
         }
     }
@@ -312,7 +311,8 @@ namespace hal
     void ModuleInfoTable::copyModule() const
     {
         auto parentMod = mModule->get_parent_module();
-        if(!parentMod) return;
+        if (!parentMod)
+            return;
 
         copyToClipboard(QString::fromStdString(parentMod->get_name()));
     }
@@ -349,7 +349,6 @@ namespace hal
 
     void ModuleInfoTable::pyCopyGatesInSubmodules() const
     {
-
     }
 
     void ModuleInfoTable::copyNumberOfSubmodules() const
@@ -425,7 +424,8 @@ namespace hal
     void ModuleInfoTable::copyParentID() const
     {
         auto parentMod = mModule->get_parent_module();
-        if(!parentMod) return;
+        if (!parentMod)
+            return;
 
         copyToClipboard(QString::number(parentMod->get_id()));
     }
@@ -443,20 +443,22 @@ namespace hal
     void ModuleInfoTable::setParentAsSelection()
     {
         auto parentMod = mModule->get_parent_module();
-        if(!parentMod) return;
+        if (!parentMod)
+            return;
 
         gSelectionRelay->clear();
         gSelectionRelay->addModule(parentMod->get_id());
-        gSelectionRelay->relaySelectionChanged(this);//function cant be const because of this
+        gSelectionRelay->relaySelectionChanged(this);    //function cant be const because of this
     }
 
     void ModuleInfoTable::addParentToSelection()
     {
         auto parentMod = mModule->get_parent_module();
-        if(!parentMod) return;
+        if (!parentMod)
+            return;
 
         gSelectionRelay->addModule(parentMod->get_id());
-        gSelectionRelay->relaySelectionChanged(this);//function cant be const because of this
+        gSelectionRelay->relaySelectionChanged(this);    //function cant be const because of this
     }
 
     void ModuleInfoTable::pyCopyGetPins() const
@@ -468,7 +470,7 @@ namespace hal
     {
         Module* parentModule = mModule->get_parent_module();
 
-        if(parentModule != nullptr)
+        if (parentModule != nullptr)
         {
             u32 parentModuleId = parentModule->get_id();
 
@@ -484,16 +486,19 @@ namespace hal
         if (mModule)
         {
             Module* parentMod = mModule->get_parent_module();
-            if (parentMod) excludeMods.insert(parentMod->get_id());
+            if (parentMod)
+                excludeMods.insert(parentMod->get_id());
         }
         ModuleDialog md(excludeMods, "Move to module", nullptr, this);
-        if (md.exec() != QDialog::Accepted) return;
+        if (md.exec() != QDialog::Accepted)
+            return;
         if (md.isNewModule())
         {
             QString topModName = QString::fromStdString(gNetlist->get_top_module()->get_name());
             bool ok;
             QString name = QInputDialog::getText(nullptr, "", "New module will be created under \"" + topModName + "\"\nModule Name:", QLineEdit::Normal, "", &ok);
-            if (!ok || name.isEmpty()) return;
+            if (!ok || name.isEmpty())
+                return;
 
             ActionCreateObject* actNewModule = new ActionCreateObject(UserActionObjectType::Module, name);
             actNewModule->setParentId(gNetlist->get_top_module()->get_id());
@@ -507,7 +512,6 @@ namespace hal
         ActionAddItemsToObject* addAct = new ActionAddItemsToObject(QSet<u32>() << mModule->get_id());
         addAct->setObject(UserActionObject(md.selectedId(), UserActionObjectType::Module));
         addAct->exec();
-
     }
 
     void ModuleInfoTable::refresh()
@@ -517,7 +521,7 @@ namespace hal
 
     void ModuleInfoTable::handleModuleRemoved(Module* module)
     {
-        if(mModule == module)
+        if (mModule == module)
         {
             mModule = nullptr;
 
@@ -537,7 +541,7 @@ namespace hal
 
     void ModuleInfoTable::handleModuleChanged(Module* module)
     {
-        if(mModule == module)
+        if (mModule == module)
             refresh();
     }
 
@@ -545,10 +549,10 @@ namespace hal
     {
         Q_UNUSED(affectedModuleId);
 
-        if(!mModule)
+        if (!mModule)
             return;
 
-        if(mModule == parentModule || mModule->contains_module(parentModule))
+        if (mModule == parentModule || mModule->is_parent_module_of(parentModule))
             refresh();
     }
 
@@ -556,10 +560,10 @@ namespace hal
     {
         Q_UNUSED(affectedGateId);
 
-        if(!mModule)
+        if (!mModule)
             return;
 
-        if(mModule == parentModule || mModule->contains_module(parentModule))
+        if (mModule == parentModule || mModule->is_parent_module_of(parentModule))
             refresh();
     }
 
@@ -567,13 +571,13 @@ namespace hal
     {
         Q_UNUSED(net);
 
-        if(!mModule)
+        if (!mModule)
             return;
 
-        Gate* affectedGate = gNetlist->get_gate_by_id(affectedGateId);
+        Gate* affectedGate               = gNetlist->get_gate_by_id(affectedGateId);
         std::vector<Gate*> allChildGates = mModule->get_gates(nullptr, true);
 
-        if(std::find(std::begin(allChildGates), std::end(allChildGates), affectedGate) != std::end(allChildGates))
+        if (std::find(std::begin(allChildGates), std::end(allChildGates), affectedGate) != std::end(allChildGates))
             refresh();
     }
-}
+}    // namespace hal

--- a/src/netlist/gate.cpp
+++ b/src/netlist/gate.cpp
@@ -194,7 +194,7 @@ namespace hal
 
         if (recursive)
         {
-            std::vector<Module*> more = m_module->get_parent_modules(filter, true);
+            std::vector<Module*> more = m_module->get_parent_modules(filter);
             res.reserve(res.size() + more.size());
             res.insert(res.end(), more.begin(), more.end());
         }

--- a/src/python_bindings/bindings/module.cpp
+++ b/src/python_bindings/bindings/module.cpp
@@ -91,15 +91,15 @@ namespace hal
         )");
 
         py_module.def_property_readonly("submodule_depth", &Module::get_submodule_depth, R"(
-            The depth of the module within the module hierarchie (0 = top module, 1 = direct child of top module, ...).
+            The depth of the module within the module hierarchy (0 = top module, 1 = direct child of top module, ...).
 
             :type: int
         )");
 
         py_module.def("get_submodule_depth", &Module::get_submodule_depth, R"(
-            Get the depth of the module within the module hierarchie (0 = top module, 1 = direct child of top module, ...).
+            Get the depth of the module within the module hierarchy (0 = top module, 1 = direct child of top module, ...).
 
-            :returns: The depth within the module hierarchie.
+            :returns: The depth within the module hierarchy.
             :rtype: int
         )");
 
@@ -125,13 +125,11 @@ namespace hal
             :type: list[hal_py.Module]
         )");
 
-        py_module.def("get_parent_modules", &Module::get_parent_modules, py::arg("filter") = nullptr, py::arg("recursive") = true, R"(
-            Get all parents of this module.
-            If ``recursive`` is set to ``True``, all indirect parents are also included.
+        py_module.def("get_parent_modules", &Module::get_parent_modules, py::arg("filter") = nullptr, R"(
+            Get all parents of this module, including all indirect parents.
             The optional filter is evaluated on every candidate such that the result only contains those matching the specified condition.
 
             :param lambda filter: An optional filter.
-            :param bool recursive: Set ``True`` to include indirect parents as well, ``False`` otherwise.
             :returns: A list of parent modules.
             :rtype: list[hal_py.Module]
         )");
@@ -145,11 +143,11 @@ namespace hal
             :rtype: bool
         )");
 
-        py_module.def("is_parent_module_of", &Module::is_parent_module_of, py::arg("module"), py::arg("recursive") = false, R"(
+        py_module.def("is_parent_module_of", &Module::is_parent_module_of, py::arg("module"), R"(
             Check if the module is a parent of the specified module.
+            Includes indirect parent modules.
          
             :param hal_py.Module module: The module.
-            :param bool recursive: Set ``True`` to check recursively, ``False`` otherwise.
             :returns: ``True`` if the module is a parent of the specified module, ``False`` otherwise.
             :rtype: bool
         )");
@@ -172,22 +170,12 @@ namespace hal
             :rtype: list[hal_py.Module]
         )");
 
-        py_module.def("is_submodule_of", &Module::is_submodule_of, py::arg("module"), py::arg("recursive") = false, R"(
+        py_module.def("is_submodule_of", &Module::is_submodule_of, py::arg("module"), R"(
             Check if the module is a submodule of the specified module.
+            Includes indirect submodules.
 
             :param hal_py.Module module: The module.
-            :param bool recursive: Set ``True`` to check recursively, ``False`` otherwise.
             :returns: ``True`` if the module is a submodule of the specified module, ``False`` otherwise.
-        )");
-
-        py_module.def("contains_module", &Module::contains_module, py::arg("other"), py::arg("recusive") = false, R"(
-            Checks whether another module is a submodule of this module.
-            If recursive is set to ``True``, all indirect submodules are also included.
-
-            :param hal_py.Module other: Other module to check for.
-            :param bool recursive: Set ``True`` to include indirect submodules as well, ``False`` otherwise.
-            :returns: ``True`` if the other module is a submodule, ``False`` otherwise.
-            :rtype: bool
         )");
 
         py_module.def_property_readonly("top_module", &Module::is_top_module, R"(

--- a/tests/netlist/module.cpp
+++ b/tests/netlist/module.cpp
@@ -281,23 +281,25 @@ namespace hal {
                 EXPECT_EQ(dummy_module_1->get_parent_modules(), std::vector<Module*>({top_module}));
                 EXPECT_EQ(dummy_module_2->get_parent_modules(), std::vector<Module*>({top_module}));
                 EXPECT_EQ(dummy_module_3->get_parent_modules(), std::vector<Module*>({dummy_module_1, top_module}));
-                EXPECT_EQ(dummy_module_3->get_parent_modules(nullptr, false), std::vector<Module*>({dummy_module_1}));
                 EXPECT_EQ(dummy_module_4->get_parent_modules(), std::vector<Module*>({dummy_module_1, top_module}));
-                EXPECT_EQ(dummy_module_4->get_parent_modules(nullptr, false), std::vector<Module*>({dummy_module_1}));
 
                 EXPECT_TRUE(top_module->is_parent_module_of(dummy_module_1));
+                EXPECT_FALSE(dummy_module_1->is_parent_module_of(dummy_module_1));
                 EXPECT_TRUE(top_module->is_parent_module_of(dummy_module_2));
-                EXPECT_FALSE(top_module->is_parent_module_of(dummy_module_3));
-                EXPECT_TRUE(top_module->is_parent_module_of(dummy_module_3, true));
-                EXPECT_FALSE(top_module->is_parent_module_of(dummy_module_4));
-                EXPECT_TRUE(top_module->is_parent_module_of(dummy_module_4, true));
+                EXPECT_FALSE(dummy_module_1->is_parent_module_of(dummy_module_2));
+                EXPECT_TRUE(top_module->is_parent_module_of(dummy_module_3));
+                EXPECT_TRUE(dummy_module_1->is_parent_module_of(dummy_module_3));
+                EXPECT_TRUE(top_module->is_parent_module_of(dummy_module_4));
+                EXPECT_TRUE(dummy_module_1->is_parent_module_of(dummy_module_4));
 
                 EXPECT_TRUE(dummy_module_1->is_submodule_of(top_module));
+                EXPECT_FALSE(dummy_module_1->is_submodule_of(dummy_module_1));
                 EXPECT_TRUE(dummy_module_2->is_submodule_of(top_module));
-                EXPECT_FALSE(dummy_module_3->is_submodule_of(top_module));
-                EXPECT_TRUE(dummy_module_3->is_submodule_of(top_module, true));
-                EXPECT_FALSE(dummy_module_4->is_submodule_of(top_module));
-                EXPECT_TRUE(dummy_module_4->is_submodule_of(top_module, true));
+                EXPECT_FALSE(dummy_module_2->is_submodule_of(dummy_module_1));
+                EXPECT_TRUE(dummy_module_3->is_submodule_of(top_module));
+                EXPECT_TRUE(dummy_module_3->is_submodule_of(dummy_module_1));
+                EXPECT_TRUE(dummy_module_4->is_submodule_of(top_module));
+                EXPECT_TRUE(dummy_module_4->is_submodule_of(dummy_module_1));
 
                 dummy_module_1->set_parent_module(dummy_module_2);
                 EXPECT_EQ(dummy_module_1->get_parent_module(), dummy_module_2);
@@ -313,28 +315,34 @@ namespace hal {
 
                 EXPECT_EQ(top_module->get_parent_modules(), std::vector<Module*>());
                 EXPECT_EQ(dummy_module_1->get_parent_modules(), std::vector<Module*>({dummy_module_2, top_module}));
-                EXPECT_EQ(dummy_module_1->get_parent_modules(nullptr, false), std::vector<Module*>({dummy_module_2}));
                 EXPECT_EQ(dummy_module_2->get_parent_modules(), std::vector<Module*>({top_module}));
                 EXPECT_EQ(dummy_module_3->get_parent_modules(), std::vector<Module*>({dummy_module_1, dummy_module_2, top_module}));
-                EXPECT_EQ(dummy_module_3->get_parent_modules(nullptr, false), std::vector<Module*>({dummy_module_1}));
                 EXPECT_EQ(dummy_module_4->get_parent_modules(), std::vector<Module*>({dummy_module_1, dummy_module_2, top_module}));
-                EXPECT_EQ(dummy_module_4->get_parent_modules(nullptr, false), std::vector<Module*>({dummy_module_1}));
 
-                EXPECT_FALSE(top_module->is_parent_module_of(dummy_module_1));
-                EXPECT_TRUE(top_module->is_parent_module_of(dummy_module_1, true));
+                EXPECT_TRUE(top_module->is_parent_module_of(dummy_module_1));
+                EXPECT_FALSE(dummy_module_1->is_parent_module_of(dummy_module_1));
+                EXPECT_TRUE(dummy_module_2->is_parent_module_of(dummy_module_1));
                 EXPECT_TRUE(top_module->is_parent_module_of(dummy_module_2));
-                EXPECT_FALSE(top_module->is_parent_module_of(dummy_module_3));
-                EXPECT_TRUE(top_module->is_parent_module_of(dummy_module_3, true));
-                EXPECT_FALSE(top_module->is_parent_module_of(dummy_module_4));
-                EXPECT_TRUE(top_module->is_parent_module_of(dummy_module_4, true));
+                EXPECT_FALSE(dummy_module_1->is_parent_module_of(dummy_module_2));
+                EXPECT_FALSE(dummy_module_2->is_parent_module_of(dummy_module_2));
+                EXPECT_TRUE(top_module->is_parent_module_of(dummy_module_3));
+                EXPECT_TRUE(dummy_module_1->is_parent_module_of(dummy_module_3));
+                EXPECT_TRUE(dummy_module_2->is_parent_module_of(dummy_module_3));
+                EXPECT_TRUE(top_module->is_parent_module_of(dummy_module_4));
+                EXPECT_TRUE(dummy_module_1->is_parent_module_of(dummy_module_4));
+                EXPECT_TRUE(dummy_module_2->is_parent_module_of(dummy_module_4));
 
-                EXPECT_FALSE(dummy_module_1->is_submodule_of(top_module));
-                EXPECT_TRUE(dummy_module_1->is_submodule_of(top_module, true));
+                EXPECT_TRUE(dummy_module_1->is_submodule_of(top_module));
+                EXPECT_FALSE(dummy_module_1->is_submodule_of(dummy_module_1));
                 EXPECT_TRUE(dummy_module_2->is_submodule_of(top_module));
-                EXPECT_FALSE(dummy_module_3->is_submodule_of(top_module));
-                EXPECT_TRUE(dummy_module_3->is_submodule_of(top_module, true));
-                EXPECT_FALSE(dummy_module_4->is_submodule_of(top_module));
-                EXPECT_TRUE(dummy_module_4->is_submodule_of(top_module, true));
+                EXPECT_FALSE(dummy_module_2->is_submodule_of(dummy_module_1));
+                EXPECT_TRUE(dummy_module_1->is_submodule_of(dummy_module_2));
+                EXPECT_TRUE(dummy_module_3->is_submodule_of(top_module));
+                EXPECT_TRUE(dummy_module_3->is_submodule_of(dummy_module_1));
+                EXPECT_TRUE(dummy_module_3->is_submodule_of(dummy_module_2));
+                EXPECT_TRUE(dummy_module_4->is_submodule_of(top_module));
+                EXPECT_TRUE(dummy_module_4->is_submodule_of(dummy_module_1));
+                EXPECT_TRUE(dummy_module_4->is_submodule_of(dummy_module_2));
             }
             {
                 /*  Hang m_0 to one of its childs (m_1). m_1 should be connected to the top_module afterwards
@@ -638,7 +646,7 @@ namespace hal {
      *
      *   (Remark: MODULE_0 and MODULE_2 are both named "even_module", while MODULE_1 and MODULE_3 are named "odd_module")
      *
-     * Functions: get_submodules, contains_module
+     * Functions: get_submodules, is_parent_module_of
      */
     TEST_F(ModuleTest, check_get_submodules) {
         TEST_START
@@ -660,10 +668,10 @@ namespace hal {
                     // Submodules of TOP_MODULE;
                     std::vector<Module*> exp_result = {m_0, m_1};
                     EXPECT_EQ(tm->get_submodules(nullptr, false), exp_result);
-                    EXPECT_TRUE(tm->contains_module(m_0, false));
-                    EXPECT_TRUE(tm->contains_module(m_1, false));
-                    EXPECT_FALSE(tm->contains_module(m_2, false));
-                    EXPECT_FALSE(tm->contains_module(m_3, false));
+                    EXPECT_TRUE(tm->is_parent_module_of(m_0));
+                    EXPECT_TRUE(tm->is_parent_module_of(m_1));
+                    EXPECT_TRUE(tm->is_parent_module_of(m_2));
+                    EXPECT_TRUE(tm->is_parent_module_of(m_3));
                 }
                 {
                     // Submodules of MODULE_1;
@@ -700,10 +708,10 @@ namespace hal {
                     // Submodules of TOP_MODULE;
                     std::vector<Module*> exp_result = {m_0, m_1, m_2, m_3};
                     EXPECT_EQ(tm->get_submodules(nullptr, true), exp_result);
-                    EXPECT_TRUE(tm->contains_module(m_0, true));
-                    EXPECT_TRUE(tm->contains_module(m_1, true));
-                    EXPECT_TRUE(tm->contains_module(m_2, true));
-                    EXPECT_TRUE(tm->contains_module(m_3, true));
+                    EXPECT_TRUE(tm->is_parent_module_of(m_0));
+                    EXPECT_TRUE(tm->is_parent_module_of(m_1));
+                    EXPECT_TRUE(tm->is_parent_module_of(m_2));
+                    EXPECT_TRUE(tm->is_parent_module_of(m_3));
                 }
                 {
                     // Submodules of TOP_MODULE (with module_name_filter);
@@ -717,14 +725,14 @@ namespace hal {
                 }
             }
             {
-                // Testing edge cases of contains_module
+                // Testing edge cases of is_parent_module_of
 
                 // -- the passed Module is a nullptr
-                EXPECT_FALSE(tm->contains_module(nullptr, false));
+                EXPECT_FALSE(tm->is_parent_module_of(nullptr));
                 // -- the calling Module is a leave
-                EXPECT_FALSE(m_2->contains_module(tm, false));
+                EXPECT_FALSE(m_2->is_parent_module_of(tm));
                 // -- the passed Module is the same as the calling one
-                EXPECT_FALSE(m_2->contains_module(m_2, false));
+                EXPECT_FALSE(m_2->is_parent_module_of(m_2));
             }
         TEST_END
     }


### PR DESCRIPTION
* significantly improves speed when checking whether a module is parent module of another one
* got rid of `recursive` flags here and there, might add their functionality as part of a filter later
* got rid of `Module::contains_module` as `Module::is_parent_module_of` has equivalent functionality