### PR TITLE
netlist_simulator_controller: fix build with gcc 13

### DIFF
--- a/plugins/simulator/netlist_simulator_controller/include/netlist_simulator_controller/saleae_directory.h
+++ b/plugins/simulator/netlist_simulator_controller/include/netlist_simulator_controller/saleae_directory.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
+#include <cstdint>
 
 // unfortunately std::filesystem::path is not available for all platforms
 #ifdef _WIN32


### PR DESCRIPTION
Without this we get

```
In file included from /build/source/plugins/simulator/netlist_simulator_controller/include/netlist_simulator_controller/saleae_file.h:33,
                 from /build/source/plugins/simulator/netlist_simulator_controller/src/saleae_file.cpp:5:
/build/source/plugins/simulator/netlist_simulator_controller/include/netlist_simulator_controller/saleae_directory.h:79:9: error: 'uint64_t' does not name a type
   79 |         uint64_t mBeginTime;
      |         ^~~~~~~~

```

when building the NixOS package now we've switched to gcc 13