### PR TITLE
Fix macOS build

### DIFF
--- a/src/netlist/boolean_function/parser_standard.cpp
+++ b/src/netlist/boolean_function/parser_standard.cpp
@@ -5,6 +5,8 @@
 #include <boost/fusion/sequence/intrinsic/at_c.hpp>
 #include <boost/spirit/home/x3.hpp>
 
+#include <sstream>
+
 namespace hal
 {
     namespace BooleanFunctionParser

--- a/src/netlist/boolean_function/simplification_abc.cpp
+++ b/src/netlist/boolean_function/simplification_abc.cpp
@@ -5,6 +5,7 @@
 #include <boost/spirit/home/x3.hpp>
 #include <mutex>
 #include <string.h>
+#include <sstream>
 
 extern "C" {
 ////////////////////////////////////////////////////////////////////////////

--- a/src/netlist/boolean_function/types.cpp
+++ b/src/netlist/boolean_function/types.cpp
@@ -3,6 +3,7 @@
 #include <boost/spirit/home/x3.hpp>
 #include <mutex>
 #include <numeric>
+#include <sstream>
 
 namespace hal
 {


### PR DESCRIPTION
Inserts missing import of `sstream` in several locations, which fixes the build that was broken on the 12.7.4 version of the macOS runner.