### PR TITLE
Add NetlistTraversalDecorator

### DIFF
--- a/documentation/sphinx_doc/netlist_traversal_decorator.rst
+++ b/documentation/sphinx_doc/netlist_traversal_decorator.rst
@@ -1,0 +1,7 @@
+Netlist Traversal Decorator
+==================================
+
+.. autoclass:: hal_py.NetlistTraversalDecorator
+   :members:
+
+   .. automethod:: __init__

--- a/include/hal_core/doxy_groups.h
+++ b/include/hal_core/doxy_groups.h
@@ -33,6 +33,11 @@
  */
 
 /**
+ * @defgroup decorators Decorators
+ * @ingroup core
+ */
+
+/**
  * @defgroup pins Pins
  * @ingroup core
  */

--- a/include/hal_core/netlist/decorators/boolean_function_decorator.h
+++ b/include/hal_core/netlist/decorators/boolean_function_decorator.h
@@ -33,6 +33,11 @@
 
 namespace hal
 {
+    /**
+     * A Boolean function decorator that provides functionality to operate on the associated Boolean function.
+     *
+     * @ingroup decorators
+     */
     class NETLIST_API BooleanFunctionDecorator
     {
     public:

--- a/include/hal_core/netlist/decorators/boolean_function_net_decorator.h
+++ b/include/hal_core/netlist/decorators/boolean_function_net_decorator.h
@@ -31,6 +31,11 @@
 
 namespace hal
 {
+    /**
+     * A net decorator that provides functionality to translate between nets and Boolean function variables.
+     *
+     * @ingroup decorators
+     */
     class NETLIST_API BooleanFunctionNetDecorator
     {
     public:

--- a/include/hal_core/netlist/decorators/netlist_modification_decorator.h
+++ b/include/hal_core/netlist/decorators/netlist_modification_decorator.h
@@ -32,6 +32,11 @@
 
 namespace hal
 {
+    /**
+     * A netlist decorator that provides functionality to modify the associated netlist.
+     *
+     * @ingroup decorators
+     */
     class NETLIST_API NetlistModificationDecorator
     {
     public:

--- a/include/hal_core/netlist/decorators/netlist_traversal_decorator.h
+++ b/include/hal_core/netlist/decorators/netlist_traversal_decorator.h
@@ -51,6 +51,8 @@ namespace hal
          * Traverse over gates that do not meet the `target_gate_filter` condition.
          * Stop traversal if (1) `continue_on_match` is `false` the `target_gate_filter` evaluates to `true`, (2) the `exit_endpoint_filter` evaluates to `false` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal), or (3) the `entry_endpoint_filter` evaluates to `false` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
          * Both the `entry_endpoint_filter` and the `exit_endpoint_filter` may be omitted.
+         * Provide a cache to speed up traversal when calling this function multiple times on the same netlist using the same forbidden pins.
+         * Do not use a cache if the filter functions operate on the `current_depth`.
          * 
          * @param[in] net - Start net.
          * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
@@ -58,6 +60,7 @@ namespace hal
          * @param[in] continue_on_match - Set `true` to continue even if `target_gate_filter` evaluated to `true`, `false` otherwise. Defaults to `false`.
          * @param[in] exit_endpoint_filter - Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
          * @param[in] entry_endpoint_filter - Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
+         * @param[inout] cache - An optional cache that can be used for better performance on repeated calls. Defaults to a `nullptr`.
          * @returns The next gates fulfilling the target gate filter condition on success, an error otherwise.
          */
         Result<std::set<Gate*>> get_next_matching_gates(const Net* net,
@@ -65,13 +68,15 @@ namespace hal
                                                         const std::function<bool(const Gate*)>& target_gate_filter,
                                                         bool continue_on_match                                                                     = false,
                                                         const std::function<bool(const Endpoint*, const u32 current_depth)>& exit_endpoint_filter  = nullptr,
-                                                        const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr) const;
+                                                        const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr,
+                                                        std::unordered_map<const Net*, std::set<Gate*>>* cache                                     = nullptr) const;
 
         /**
          * Starting from the given gate, traverse the netlist and return only the successor/predecessor gates for which the `target_gate_filter` evaluates to `true`.
          * Traverse over gates that do not meet the `target_gate_filter` condition.
          * Stop traversal if (1) `continue_on_match` is `false` the `target_gate_filter` evaluates to `true`, (2) the `exit_endpoint_filter` evaluates to `false` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal), or (3) the `entry_endpoint_filter` evaluates to `false` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
          * Both the `entry_endpoint_filter` and the `exit_endpoint_filter` may be omitted.
+         * Do not use a cache if the filter functions operate on the `current_depth`.
          * 
          * @param[in] gate - Start gate.
          * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
@@ -79,6 +84,7 @@ namespace hal
          * @param[in] continue_on_match - Set `true` to continue even if `target_gate_filter` evaluated to `true`, `false` otherwise. Defaults to `false`.
          * @param[in] exit_endpoint_filter - Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
          * @param[in] entry_endpoint_filter - Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
+         * @param[inout] cache - An optional cache that can be used for better performance on repeated calls. Defaults to a `nullptr`.
          * @returns The next gates fulfilling the target gate filter condition on success, an error otherwise.
          */
         Result<std::set<Gate*>> get_next_matching_gates(const Gate* gate,
@@ -86,7 +92,8 @@ namespace hal
                                                         const std::function<bool(const Gate*)>& target_gate_filter,
                                                         bool continue_on_match                                                                     = false,
                                                         const std::function<bool(const Endpoint*, const u32 current_depth)>& exit_endpoint_filter  = nullptr,
-                                                        const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr) const;
+                                                        const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr,
+                                                        std::unordered_map<const Net*, std::set<Gate*>>* cache                                     = nullptr) const;
 
         /**
          * Starting from the given net, traverse the netlist and return only the successor/predecessor gates for which the `target_gate_filter` evaluates to `true`.

--- a/include/hal_core/netlist/decorators/netlist_traversal_decorator.h
+++ b/include/hal_core/netlist/decorators/netlist_traversal_decorator.h
@@ -125,6 +125,38 @@ namespace hal
                                                               const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr) const;
 
         /**
+         * Starting from the given net, traverse the netlist and return only the successor/predecessor gates for which the `target_gate_filter` evaluates to `true`.
+         * Continue traversal independent of whatever `target_gate_filter` evaluates to.
+         * Stop traversal if the specified depth is reached.
+         * The current depth is counted starting at 1 for the destinations of the provided net. 
+         * If no depth is provided, all gates between the start net and the global netlist outputs will be traversed.
+         * The target_gate_filter may be omitted in which case all traversed gates will be returned.
+         * 
+         * @param[in] net - Start net.
+         * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
+         * @param[in] target_gate_filter - Filter condition that must be met for the target gates.
+         * @param[in] max_depth - The maximum depth for netlist traversal starting from the start net.
+         * @returns The next gates fulfilling the target gate filter condition on success, an error otherwise.
+         */
+        Result<std::set<Gate*>> get_next_matching_gates_until_depth(const Net* net, bool successors, const std::function<bool(const Gate*)>& target_gate_filter = nullptr, u32 max_depth = 0) const;
+
+        /**
+         * Starting from the given gate, traverse the netlist and return only the successor/predecessor gates for which the `target_gate_filter` evaluates to `true`.
+         * Continue traversal independent of whatever `target_gate_filter` evaluates to.
+         * Stop traversal if the specified depth is reached.
+         * The current depth is counted starting at 1 for the direct successors/predecessors of the provided gate. 
+         * If no depth is provided, all gates between the start gate and the global netlist outputs will be traversed.
+         * The target_gate_filter may be omitted in which case all traversed gates will be returned.
+         * 
+         * @param[in] gate - Start gate.
+         * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
+         * @param[in] target_gate_filter - Filter condition that must be met for the target gates.
+         * @param[in] max_depth - The maximum depth for netlist traversal starting from the start gate.
+         * @returns The next gates fulfilling the target gate filter condition on success, an error otherwise.
+         */
+        Result<std::set<Gate*>> get_next_matching_gates_until_depth(const Gate* gate, bool successors, const std::function<bool(const Gate*)>& target_gate_filter = nullptr, u32 max_depth = 0) const;
+
+        /**
          * Starting from the given net, traverse the netlist and return only the next layer of sequential successor/predecessor gates.
          * Traverse over gates that are not sequential until a sequential gate is found.
          * Stop traversal at all sequential gates, but only adds those to the result that have not been reached through a pin of one of the forbidden types.

--- a/include/hal_core/netlist/decorators/netlist_traversal_decorator.h
+++ b/include/hal_core/netlist/decorators/netlist_traversal_decorator.h
@@ -186,8 +186,6 @@ namespace hal
         Result<std::set<Gate*>>
             get_next_sequential_gates(const Gate* gate, bool successors, const std::set<PinType>& forbidden_pins, std::unordered_map<const Net*, std::set<Gate*>>* cache = nullptr) const;
 
-        // TODO implement get_next_combinational_gates (get all combinational successor gates until sequential (non-combinational) gates are hit)
-
         /**
          * Get the next sequential gates for all sequential gates in the netlist by traversing through remaining logic (e.g., combinational logic).
          * Compute a map from a sequential gate to all its successors.
@@ -198,6 +196,32 @@ namespace hal
          * @returns A map from each sequential gate to all its sequential successors on success, an error otherwise.
          */
         Result<std::map<Gate*, std::set<Gate*>>> get_next_sequential_gates_map(bool successors, const std::set<PinType>& forbidden_pins) const;
+
+        /**
+         * Starting from the given net, traverse the netlist and return all combinational successor/predecessor gates.
+         * Continue traversal as long as further combinational gates are found and stop at gates that are not combinational.
+         * All combinational gates found during traversal are added to the result.
+         * Provide a cache to speed up traversal when calling this function multiple times on the same netlist.
+         * 
+         * @param[in] net - Start net.
+         * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
+         * @param[inout] cache - An optional cache that can be used for better performance on repeated calls. Defaults to a `nullptr`.
+         * @returns The next combinational gates on success, an error otherwise.
+         */
+        Result<std::set<Gate*>> get_next_combinational_gates(const Net* net, bool successors, std::unordered_map<const Net*, std::set<Gate*>>* cache = nullptr) const;
+
+        /**
+         * Starting from the given gate, traverse the netlist and return all combinational successor/predecessor gates.
+         * Continue traversal as long as further combinational gates are found and stop at gates that are not combinational.
+         * All combinational gates found during traversal are added to the result.
+         * Provide a cache to speed up traversal when calling this function multiple times on the same netlist.
+         * 
+         * @param[in] gate - Start gate.
+         * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
+         * @param[inout] cache - An optional cache that can be used for better performance on repeated calls. Defaults to a `nullptr`.
+         * @returns The next combinational gates on success, an error otherwise.
+         */
+        Result<std::set<Gate*>> get_next_combinational_gates(const Gate* gate, bool successors, std::unordered_map<const Net*, std::set<Gate*>>* cache = nullptr) const;
 
         // TODO move get_path and get_shortest_path here
 

--- a/include/hal_core/netlist/decorators/netlist_traversal_decorator.h
+++ b/include/hal_core/netlist/decorators/netlist_traversal_decorator.h
@@ -132,12 +132,12 @@ namespace hal
          * 
          * @param[in] net - Start net.
          * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
-         * @param[in] forbidden_pins - Sequential gates reached through these pins will not be part of the result. Defaults to an empty set.
-         * @param[in] cache - An optional cache that can be used for better performance on repeated calls. Defaults to a `nullptr`.
+         * @param[in] forbidden_pins - Sequential gates reached through these pins will not be part of the result.
+         * @param[inout] cache - An optional cache that can be used for better performance on repeated calls. Defaults to a `nullptr`.
          * @returns The next sequential gates.
          */
         Result<std::set<Gate*>>
-            get_next_sequential_gates(const Net* net, bool successors, const std::set<PinType>& forbidden_pins = {}, std::unordered_map<const Net*, std::set<Gate*>>* cache = nullptr) const;
+            get_next_sequential_gates(const Net* net, bool successors, const std::set<PinType>& forbidden_pins, std::unordered_map<const Net*, std::set<Gate*>>* cache = nullptr) const;
 
         /**
          * Starting from the given gate, traverse the netlist and return only the next layer of sequential successor/predecessor gates.
@@ -147,12 +147,12 @@ namespace hal
          * 
          * @param[in] gate - Start gate.
          * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
-         * @param[in] forbidden_pins - Sequential gates reached through these pins will not be part of the result. Defaults to an empty set.
-         * @param[in] cache - An optional cache that can be used for better performance on repeated calls. Defaults to a `nullptr`.
+         * @param[in] forbidden_pins - Sequential gates reached through these pins will not be part of the result.
+         * @param[inout] cache - An optional cache that can be used for better performance on repeated calls. Defaults to a `nullptr`.
          * @returns The next sequential gates.
          */
         Result<std::set<Gate*>>
-            get_next_sequential_gates(const Gate* gate, bool successors, const std::set<PinType>& forbidden_pins = {}, std::unordered_map<const Net*, std::set<Gate*>>* cache = nullptr) const;
+            get_next_sequential_gates(const Gate* gate, bool successors, const std::set<PinType>& forbidden_pins, std::unordered_map<const Net*, std::set<Gate*>>* cache = nullptr) const;
 
         // TODO implement get_next_combinational_gates (get all combinational successor gates until sequential (non-combinational) gates are hit)
 

--- a/include/hal_core/netlist/decorators/netlist_traversal_decorator.h
+++ b/include/hal_core/netlist/decorators/netlist_traversal_decorator.h
@@ -1,0 +1,139 @@
+// MIT License
+//
+// Copyright (c) 2019 Ruhr University Bochum, Chair for Embedded Security. All Rights reserved.
+// Copyright (c) 2019 Marc Fyrbiak, Sebastian Wallat, Max Hoffmann ("ORIGINAL AUTHORS"). All rights reserved.
+// Copyright (c) 2021 Max Planck Institute for Security and Privacy. All Rights reserved.
+// Copyright (c) 2021 Jörn Langheinrich, Julian Speith, Nils Albartus, René Walendy, Simon Klix ("ORIGINAL AUTHORS"). All Rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "hal_core/defines.h"
+#include "hal_core/netlist/netlist.h"
+#include "hal_core/utilities/result.h"
+
+namespace hal
+{
+    /**
+     * A netlist decorator that provides functionality to traverse the associated netlist without making any modifications.
+     *
+     * @ingroup decorators
+     */
+    class NETLIST_API NetlistTraversalDecorator
+    {
+    public:
+        /**
+         * Construct new NetlistTraversalDecorator object.
+         * 
+         * @param[in] netlist - The netlist to operate on.
+         */
+        NetlistTraversalDecorator(const Netlist& netlist);
+
+        /**
+         * Starting from the given net, traverse the netlist and return only the successor/predecessor gates for which the `target_gate_filter` evaluates to `true`.
+         * Traverse over gates that do not meet the `target_gate_filter` condition.
+         * Stop traversal if (1) the `target_gate_filter` evaluates to `true`, (2) the `exit_endpoint_filter` evaluates to `false` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal), or (3) the `entry_endpoint_filter` evaluates to `false` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
+         * Both the `entry_endpoint_filter` and the `exit_endpoint_filter` may be omitted.
+         * 
+         * @param[in] net - Start net.
+         * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
+         * @param[in] target_gate_filter - Filter condition that must be met for the target gates.
+         * @param[in] exit_endpoint_filter - Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
+         * @param[in] entry_endpoint_filter - Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
+         * @returns The next gates fulfilling the target gate filter condition.
+         */
+        Result<std::set<Gate*>> get_next_matching_gates(const Net* net,
+                                                        bool successors,
+                                                        const std::function<bool(const Gate*)>& target_gate_filter,
+                                                        const std::function<bool(const Endpoint*, const u32 current_depth)>& exit_endpoint_filter  = nullptr,
+                                                        const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr) const;
+
+        /**
+         * Starting from the given gate, traverse the netlist and return only the successor/predecessor gates for which the `target_gate_filter` evaluates to `true`.
+         * Traverse over gates that do not meet the `target_gate_filter` condition.
+         * Stop traversal if (1) the `target_gate_filter` evaluates to `true`, (2) the `exit_endpoint_filter` evaluates to `false` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal), or (3) the `entry_endpoint_filter` evaluates to `false` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
+         * Both the `entry_endpoint_filter` and the `exit_endpoint_filter` may be omitted.
+         * 
+         * @param[in] gate - Start gate.
+         * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
+         * @param[in] target_gate_filter - Filter condition that must be met for the target gates.
+         * @param[in] exit_endpoint_filter - Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
+         * @param[in] entry_endpoint_filter - Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
+         * @returns The next gates fulfilling the target gate filter condition.
+         */
+        Result<std::set<Gate*>> get_next_matching_gates(const Gate* gate,
+                                                        bool successors,
+                                                        const std::function<bool(const Gate*)>& target_gate_filter,
+                                                        const std::function<bool(const Endpoint*, const u32 current_depth)>& exit_endpoint_filter  = nullptr,
+                                                        const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr) const;
+
+        /**
+         * Starting from the given net, traverse the netlist and return only the successor/predecessor gates for which the `target_gate_filter` evaluates to `true`.
+         * Continues traversal independent of whatever `target_gate_filter` evaluates to.
+         * Stop traversal if (1) the `exit_endpoint_filter` evaluates to `false` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal) or (2) the `entry_endpoint_filter` evaluates to `false` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
+         * The target_gate_filter may be omitted in which case all traversed gates will be returned.
+         * Both `entry_endpoint_filter` and the `exit_endpoint_filter` may be omitted as well.
+         * 
+         * @param[in] net - Start net.
+         * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
+         * @param[in] target_gate_filter - Filter condition that must be met for the target gates.
+         * @param[in] exit_endpoint_filter - Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
+         * @param[in] entry_endpoint_filter - Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
+         * @returns The next gates fulfilling the target gate filter condition.
+         */
+        Result<std::set<Gate*>> get_next_matching_gates_until(const Net* net,
+                                                              bool successors,
+                                                              const std::function<bool(const Gate*)>& target_gate_filter                                 = nullptr,
+                                                              const std::function<bool(const Endpoint*, const u32 current_depth)>& exit_endpoint_filter  = nullptr,
+                                                              const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr) const;
+
+        /**
+         * Starting from the given gate, traverse the netlist and return only the successor/predecessor gates for which the `target_gate_filter` evaluates to `true`.
+         * Stop traversal if (1) the `exit_endpoint_filter` evaluates to `false` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal) or (2) the `entry_endpoint_filter` evaluates to `false` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
+         * The target_gate_filter may be omitted in which case all traversed gates will be returned.
+         * Both `entry_endpoint_filter` and the `exit_endpoint_filter` may be omitted as well.
+         * 
+         * @param[in] gate - Start gate.
+         * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
+         * @param[in] target_gate_filter - Filter condition that must be met for the target gates.
+         * @param[in] exit_endpoint_filter - Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
+         * @param[in] entry_endpoint_filter - Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
+         * @returns The next gates fulfilling the target gate filter condition.
+         */
+        Result<std::set<Gate*>> get_next_matching_gates_until(const Gate* gate,
+                                                              bool successors,
+                                                              const std::function<bool(const Gate*)>& target_gate_filter                                 = nullptr,
+                                                              const std::function<bool(const Endpoint*, const u32 current_depth)>& exit_endpoint_filter  = nullptr,
+                                                              const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr) const;
+
+        // TODO implement get_next_sequential_gates (get all sequential successors of the current gate by traversing other gates)
+
+        // TODO implement get_next_combinational_gates (get all combinational successor gates until sequential (non-combinational) gates are hit)
+
+        // TODO implement get_sequential_successor_map (iteratively call get_next_sequential_gates on all sequential gates and create a map)
+
+        // TODO move get_path and get_shortest_path here
+
+        // TODO move get_gate_chain and get_complex_gate_chain here
+
+    private:
+        const Netlist& m_netlist;
+    };
+}    // namespace hal

--- a/include/hal_core/netlist/decorators/netlist_traversal_decorator.h
+++ b/include/hal_core/netlist/decorators/netlist_traversal_decorator.h
@@ -123,7 +123,13 @@ namespace hal
                                                               const std::function<bool(const Endpoint*, const u32 current_depth)>& exit_endpoint_filter  = nullptr,
                                                               const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr) const;
 
-        // TODO implement get_next_sequential_gates (get all sequential successors of the current gate by traversing other gates)
+        // test & document
+        Result<std::set<Gate*>>
+            get_next_sequential_gates(const Net* net, bool successors, const std::set<PinType>& forbidden_input_pins = {}, std::unordered_map<const Net*, std::set<Gate*>>* cache = nullptr) const;
+
+        // test & document
+        Result<std::set<Gate*>>
+            get_next_sequential_gates(const Gate* gate, bool successors, const std::set<PinType>& forbidden_input_pins = {}, std::unordered_map<const Net*, std::set<Gate*>>* cache = nullptr) const;
 
         // TODO implement get_next_combinational_gates (get all combinational successor gates until sequential (non-combinational) gates are hit)
 

--- a/include/hal_core/netlist/decorators/netlist_traversal_decorator.h
+++ b/include/hal_core/netlist/decorators/netlist_traversal_decorator.h
@@ -214,7 +214,8 @@ namespace hal
          * @param[inout] cache - An optional cache that can be used for better performance on repeated calls. Defaults to a `nullptr`.
          * @returns The next combinational gates on success, an error otherwise.
          */
-        Result<std::set<Gate*>> get_next_combinational_gates(const Net* net, bool successors, std::unordered_map<const Net*, std::set<Gate*>>* cache = nullptr) const;
+        Result<std::set<Gate*>>
+            get_next_combinational_gates(const Net* net, bool successors, const std::set<PinType>& forbidden_pins, std::unordered_map<const Net*, std::set<Gate*>>* cache = nullptr) const;
 
         /**
          * Starting from the given gate, traverse the netlist and return all combinational successor/predecessor gates.
@@ -227,7 +228,8 @@ namespace hal
          * @param[inout] cache - An optional cache that can be used for better performance on repeated calls. Defaults to a `nullptr`.
          * @returns The next combinational gates on success, an error otherwise.
          */
-        Result<std::set<Gate*>> get_next_combinational_gates(const Gate* gate, bool successors, std::unordered_map<const Net*, std::set<Gate*>>* cache = nullptr) const;
+        Result<std::set<Gate*>>
+            get_next_combinational_gates(const Gate* gate, bool successors, const std::set<PinType>& forbidden_pins, std::unordered_map<const Net*, std::set<Gate*>>* cache = nullptr) const;
 
         // TODO move get_path and get_shortest_path here
 

--- a/include/hal_core/netlist/decorators/netlist_traversal_decorator.h
+++ b/include/hal_core/netlist/decorators/netlist_traversal_decorator.h
@@ -49,12 +49,13 @@ namespace hal
         /**
          * Starting from the given net, traverse the netlist and return only the successor/predecessor gates for which the `target_gate_filter` evaluates to `true`.
          * Traverse over gates that do not meet the `target_gate_filter` condition.
-         * Stop traversal if (1) the `target_gate_filter` evaluates to `true`, (2) the `exit_endpoint_filter` evaluates to `false` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal), or (3) the `entry_endpoint_filter` evaluates to `false` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
+         * Stop traversal if (1) `continue_on_match` is `false` the `target_gate_filter` evaluates to `true`, (2) the `exit_endpoint_filter` evaluates to `false` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal), or (3) the `entry_endpoint_filter` evaluates to `false` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
          * Both the `entry_endpoint_filter` and the `exit_endpoint_filter` may be omitted.
          * 
          * @param[in] net - Start net.
          * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
          * @param[in] target_gate_filter - Filter condition that must be met for the target gates.
+         * @param[in] continue_on_match - Set `true` to continue even if `target_gate_filter` evaluated to `true`, `false` otherwise. Defaults to `false`.
          * @param[in] exit_endpoint_filter - Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
          * @param[in] entry_endpoint_filter - Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
          * @returns The next gates fulfilling the target gate filter condition on success, an error otherwise.
@@ -62,18 +63,20 @@ namespace hal
         Result<std::set<Gate*>> get_next_matching_gates(const Net* net,
                                                         bool successors,
                                                         const std::function<bool(const Gate*)>& target_gate_filter,
+                                                        bool continue_on_match                                                                     = false,
                                                         const std::function<bool(const Endpoint*, const u32 current_depth)>& exit_endpoint_filter  = nullptr,
                                                         const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr) const;
 
         /**
          * Starting from the given gate, traverse the netlist and return only the successor/predecessor gates for which the `target_gate_filter` evaluates to `true`.
          * Traverse over gates that do not meet the `target_gate_filter` condition.
-         * Stop traversal if (1) the `target_gate_filter` evaluates to `true`, (2) the `exit_endpoint_filter` evaluates to `false` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal), or (3) the `entry_endpoint_filter` evaluates to `false` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
+         * Stop traversal if (1) `continue_on_match` is `false` the `target_gate_filter` evaluates to `true`, (2) the `exit_endpoint_filter` evaluates to `false` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal), or (3) the `entry_endpoint_filter` evaluates to `false` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
          * Both the `entry_endpoint_filter` and the `exit_endpoint_filter` may be omitted.
          * 
          * @param[in] gate - Start gate.
          * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
          * @param[in] target_gate_filter - Filter condition that must be met for the target gates.
+         * @param[in] continue_on_match - Set `true` to continue even if `target_gate_filter` evaluated to `true`, `false` otherwise. Defaults to `false`.
          * @param[in] exit_endpoint_filter - Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
          * @param[in] entry_endpoint_filter - Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
          * @returns The next gates fulfilling the target gate filter condition on success, an error otherwise.
@@ -81,46 +84,49 @@ namespace hal
         Result<std::set<Gate*>> get_next_matching_gates(const Gate* gate,
                                                         bool successors,
                                                         const std::function<bool(const Gate*)>& target_gate_filter,
+                                                        bool continue_on_match                                                                     = false,
                                                         const std::function<bool(const Endpoint*, const u32 current_depth)>& exit_endpoint_filter  = nullptr,
                                                         const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr) const;
 
         /**
          * Starting from the given net, traverse the netlist and return only the successor/predecessor gates for which the `target_gate_filter` evaluates to `true`.
          * Continue traversal independent of whatever `target_gate_filter` evaluates to.
-         * Stop traversal if (1) the `exit_endpoint_filter` evaluates to `false` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal) or (2) the `entry_endpoint_filter` evaluates to `false` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
-         * The target_gate_filter may be omitted in which case all traversed gates will be returned.
-         * Both `entry_endpoint_filter` and the `exit_endpoint_filter` may be omitted as well.
+         * Stop traversal if (1) `continue_on_mismatch` is `false` the `target_gate_filter` evaluates to `false`, (2) the `exit_endpoint_filter` evaluates to `false` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal), or (3) the `entry_endpoint_filter` evaluates to `false` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
+         * Both `entry_endpoint_filter` and the `exit_endpoint_filter` may be omitted.
          * 
          * @param[in] net - Start net.
          * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
          * @param[in] target_gate_filter - Filter condition that must be met for the target gates.
+         * @param[in] continue_on_mismatch - Set `true` to continue even if `target_gate_filter` evaluated to `false`, `false` otherwise. Defaults to `false`.
          * @param[in] exit_endpoint_filter - Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
          * @param[in] entry_endpoint_filter - Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
          * @returns The next gates fulfilling the target gate filter condition on success, an error otherwise.
          */
         Result<std::set<Gate*>> get_next_matching_gates_until(const Net* net,
                                                               bool successors,
-                                                              const std::function<bool(const Gate*)>& target_gate_filter                                 = nullptr,
+                                                              const std::function<bool(const Gate*)>& target_gate_filter,
+                                                              bool continue_on_mismatch                                                                  = false,
                                                               const std::function<bool(const Endpoint*, const u32 current_depth)>& exit_endpoint_filter  = nullptr,
                                                               const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr) const;
 
         /**
          * Starting from the given gate, traverse the netlist and return only the successor/predecessor gates for which the `target_gate_filter` evaluates to `true`.
          * Continue traversal independent of whatever `target_gate_filter` evaluates to.
-         * Stop traversal if (1) the `exit_endpoint_filter` evaluates to `false` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal) or (2) the `entry_endpoint_filter` evaluates to `false` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
-         * The target_gate_filter may be omitted in which case all traversed gates will be returned.
-         * Both `entry_endpoint_filter` and the `exit_endpoint_filter` may be omitted as well.
+         * Stop traversal if (1) `continue_on_mismatch` is `false` the `target_gate_filter` evaluates to `false`, (2) the `exit_endpoint_filter` evaluates to `false` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal), or (3) the `entry_endpoint_filter` evaluates to `false` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
+         * Both `entry_endpoint_filter` and the `exit_endpoint_filter` may be omitted.
          * 
          * @param[in] gate - Start gate.
          * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
          * @param[in] target_gate_filter - Filter condition that must be met for the target gates.
+         * @param[in] continue_on_mismatch - Set `true` to continue even if `target_gate_filter` evaluated to `false`, `false` otherwise. Defaults to `false`.
          * @param[in] exit_endpoint_filter - Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
          * @param[in] entry_endpoint_filter - Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
          * @returns The next gates fulfilling the target gate filter condition on success, an error otherwise.
          */
         Result<std::set<Gate*>> get_next_matching_gates_until(const Gate* gate,
                                                               bool successors,
-                                                              const std::function<bool(const Gate*)>& target_gate_filter                                 = nullptr,
+                                                              const std::function<bool(const Gate*)>& target_gate_filter,
+                                                              bool continue_on_mismatch                                                                  = false,
                                                               const std::function<bool(const Endpoint*, const u32 current_depth)>& exit_endpoint_filter  = nullptr,
                                                               const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr) const;
 
@@ -129,32 +135,32 @@ namespace hal
          * Continue traversal independent of whatever `target_gate_filter` evaluates to.
          * Stop traversal if the specified depth is reached.
          * The current depth is counted starting at 1 for the destinations of the provided net. 
-         * If no depth is provided, all gates between the start net and the global netlist outputs will be traversed.
+         * For a `depth` of `0`, all nets between the start gate and the global netlist outputs will be traversed.
          * The target_gate_filter may be omitted in which case all traversed gates will be returned.
          * 
          * @param[in] net - Start net.
          * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
-         * @param[in] target_gate_filter - Filter condition that must be met for the target gates.
          * @param[in] max_depth - The maximum depth for netlist traversal starting from the start net.
+         * @param[in] target_gate_filter - Filter condition that must be met for the target gates.
          * @returns The next gates fulfilling the target gate filter condition on success, an error otherwise.
          */
-        Result<std::set<Gate*>> get_next_matching_gates_until_depth(const Net* net, bool successors, const std::function<bool(const Gate*)>& target_gate_filter = nullptr, u32 max_depth = 0) const;
+        Result<std::set<Gate*>> get_next_matching_gates_until_depth(const Net* net, bool successors, u32 max_depth, const std::function<bool(const Gate*)>& target_gate_filter = nullptr) const;
 
         /**
          * Starting from the given gate, traverse the netlist and return only the successor/predecessor gates for which the `target_gate_filter` evaluates to `true`.
          * Continue traversal independent of whatever `target_gate_filter` evaluates to.
          * Stop traversal if the specified depth is reached.
          * The current depth is counted starting at 1 for the direct successors/predecessors of the provided gate. 
-         * If no depth is provided, all gates between the start gate and the global netlist outputs will be traversed.
+         * For a `depth` of `0`, all gates between the start gate and the global netlist outputs will be traversed.
          * The target_gate_filter may be omitted in which case all traversed gates will be returned.
          * 
          * @param[in] gate - Start gate.
          * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
-         * @param[in] target_gate_filter - Filter condition that must be met for the target gates.
          * @param[in] max_depth - The maximum depth for netlist traversal starting from the start gate.
+         * @param[in] target_gate_filter - Filter condition that must be met for the target gates.
          * @returns The next gates fulfilling the target gate filter condition on success, an error otherwise.
          */
-        Result<std::set<Gate*>> get_next_matching_gates_until_depth(const Gate* gate, bool successors, const std::function<bool(const Gate*)>& target_gate_filter = nullptr, u32 max_depth = 0) const;
+        Result<std::set<Gate*>> get_next_matching_gates_until_depth(const Gate* gate, bool successors, u32 max_depth, const std::function<bool(const Gate*)>& target_gate_filter = nullptr) const;
 
         /**
          * Starting from the given net, traverse the netlist and return only the next layer of sequential successor/predecessor gates.

--- a/include/hal_core/netlist/decorators/netlist_traversal_decorator.h
+++ b/include/hal_core/netlist/decorators/netlist_traversal_decorator.h
@@ -57,7 +57,7 @@ namespace hal
          * @param[in] target_gate_filter - Filter condition that must be met for the target gates.
          * @param[in] exit_endpoint_filter - Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
          * @param[in] entry_endpoint_filter - Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
-         * @returns The next gates fulfilling the target gate filter condition.
+         * @returns The next gates fulfilling the target gate filter condition on success, an error otherwise.
          */
         Result<std::set<Gate*>> get_next_matching_gates(const Net* net,
                                                         bool successors,
@@ -76,7 +76,7 @@ namespace hal
          * @param[in] target_gate_filter - Filter condition that must be met for the target gates.
          * @param[in] exit_endpoint_filter - Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
          * @param[in] entry_endpoint_filter - Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
-         * @returns The next gates fulfilling the target gate filter condition.
+         * @returns The next gates fulfilling the target gate filter condition on success, an error otherwise.
          */
         Result<std::set<Gate*>> get_next_matching_gates(const Gate* gate,
                                                         bool successors,
@@ -96,7 +96,7 @@ namespace hal
          * @param[in] target_gate_filter - Filter condition that must be met for the target gates.
          * @param[in] exit_endpoint_filter - Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
          * @param[in] entry_endpoint_filter - Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
-         * @returns The next gates fulfilling the target gate filter condition.
+         * @returns The next gates fulfilling the target gate filter condition on success, an error otherwise.
          */
         Result<std::set<Gate*>> get_next_matching_gates_until(const Net* net,
                                                               bool successors,
@@ -116,7 +116,7 @@ namespace hal
          * @param[in] target_gate_filter - Filter condition that must be met for the target gates.
          * @param[in] exit_endpoint_filter - Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
          * @param[in] entry_endpoint_filter - Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
-         * @returns The next gates fulfilling the target gate filter condition.
+         * @returns The next gates fulfilling the target gate filter condition on success, an error otherwise.
          */
         Result<std::set<Gate*>> get_next_matching_gates_until(const Gate* gate,
                                                               bool successors,
@@ -127,14 +127,14 @@ namespace hal
         /**
          * Starting from the given net, traverse the netlist and return only the next layer of sequential successor/predecessor gates.
          * Traverse over gates that are not sequential until a sequential gate is found.
-         * Stops at all sequential gates, but only adds those to the result that have not been reached through a pin of one of the forbidden types.
+         * Stop traversal at all sequential gates, but only adds those to the result that have not been reached through a pin of one of the forbidden types.
          * Provide a cache to speed up traversal when calling this function multiple times on the same netlist using the same forbidden pins.
          * 
          * @param[in] net - Start net.
          * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
          * @param[in] forbidden_pins - Sequential gates reached through these pins will not be part of the result.
          * @param[inout] cache - An optional cache that can be used for better performance on repeated calls. Defaults to a `nullptr`.
-         * @returns The next sequential gates.
+         * @returns The next sequential gates on success, an error otherwise.
          */
         Result<std::set<Gate*>>
             get_next_sequential_gates(const Net* net, bool successors, const std::set<PinType>& forbidden_pins, std::unordered_map<const Net*, std::set<Gate*>>* cache = nullptr) const;
@@ -142,21 +142,30 @@ namespace hal
         /**
          * Starting from the given gate, traverse the netlist and return only the next layer of sequential successor/predecessor gates.
          * Traverse over gates that are not sequential until a sequential gate is found.
-         * Stops at all sequential gates, but only adds those to the result that have not been reached through a pin of one of the forbidden types.
+         * Stop traversal at all sequential gates, but only adds those to the result that have not been reached through a pin of one of the forbidden types.
          * Provide a cache to speed up traversal when calling this function multiple times on the same netlist using the same forbidden pins.
          * 
          * @param[in] gate - Start gate.
          * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
          * @param[in] forbidden_pins - Sequential gates reached through these pins will not be part of the result.
          * @param[inout] cache - An optional cache that can be used for better performance on repeated calls. Defaults to a `nullptr`.
-         * @returns The next sequential gates.
+         * @returns The next sequential gates on success, an error otherwise.
          */
         Result<std::set<Gate*>>
             get_next_sequential_gates(const Gate* gate, bool successors, const std::set<PinType>& forbidden_pins, std::unordered_map<const Net*, std::set<Gate*>>* cache = nullptr) const;
 
         // TODO implement get_next_combinational_gates (get all combinational successor gates until sequential (non-combinational) gates are hit)
 
-        // TODO implement get_sequential_successor_map (iteratively call get_next_sequential_gates on all sequential gates and create a map)
+        /**
+         * Get the next sequential gates for all sequential gates in the netlist by traversing through remaining logic (e.g., combinational logic).
+         * Compute a map from a sequential gate to all its successors.
+         * Stop traversal at all sequential gates, but only adds those to the result that have not been reached through a pin of one of the forbidden types.
+         * 
+         * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
+         * @param[in] forbidden_pins - Sequential gates reached through these pins will not be part of the result.
+         * @returns A map from each sequential gate to all its sequential successors on success, an error otherwise.
+         */
+        Result<std::map<Gate*, std::set<Gate*>>> get_next_sequential_gates_map(bool successors, const std::set<PinType>& forbidden_pins) const;
 
         // TODO move get_path and get_shortest_path here
 

--- a/include/hal_core/netlist/decorators/netlist_traversal_decorator.h
+++ b/include/hal_core/netlist/decorators/netlist_traversal_decorator.h
@@ -86,7 +86,7 @@ namespace hal
 
         /**
          * Starting from the given net, traverse the netlist and return only the successor/predecessor gates for which the `target_gate_filter` evaluates to `true`.
-         * Continues traversal independent of whatever `target_gate_filter` evaluates to.
+         * Continue traversal independent of whatever `target_gate_filter` evaluates to.
          * Stop traversal if (1) the `exit_endpoint_filter` evaluates to `false` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal) or (2) the `entry_endpoint_filter` evaluates to `false` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
          * The target_gate_filter may be omitted in which case all traversed gates will be returned.
          * Both `entry_endpoint_filter` and the `exit_endpoint_filter` may be omitted as well.
@@ -106,6 +106,7 @@ namespace hal
 
         /**
          * Starting from the given gate, traverse the netlist and return only the successor/predecessor gates for which the `target_gate_filter` evaluates to `true`.
+         * Continue traversal independent of whatever `target_gate_filter` evaluates to.
          * Stop traversal if (1) the `exit_endpoint_filter` evaluates to `false` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal) or (2) the `entry_endpoint_filter` evaluates to `false` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
          * The target_gate_filter may be omitted in which case all traversed gates will be returned.
          * Both `entry_endpoint_filter` and the `exit_endpoint_filter` may be omitted as well.
@@ -123,13 +124,35 @@ namespace hal
                                                               const std::function<bool(const Endpoint*, const u32 current_depth)>& exit_endpoint_filter  = nullptr,
                                                               const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr) const;
 
-        // test & document
+        /**
+         * Starting from the given net, traverse the netlist and return only the next layer of sequential successor/predecessor gates.
+         * Traverse over gates that are not sequential until a sequential gate is found.
+         * Stops at all sequential gates, but only adds those to the result that have not been reached through a pin of one of the forbidden types.
+         * Provide a cache to speed up traversal when calling this function multiple times on the same netlist using the same forbidden pins.
+         * 
+         * @param[in] net - Start net.
+         * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
+         * @param[in] forbidden_pins - Sequential gates reached through these pins will not be part of the result. Defaults to an empty set.
+         * @param[in] cache - An optional cache that can be used for better performance on repeated calls. Defaults to a `nullptr`.
+         * @returns The next sequential gates.
+         */
         Result<std::set<Gate*>>
-            get_next_sequential_gates(const Net* net, bool successors, const std::set<PinType>& forbidden_input_pins = {}, std::unordered_map<const Net*, std::set<Gate*>>* cache = nullptr) const;
+            get_next_sequential_gates(const Net* net, bool successors, const std::set<PinType>& forbidden_pins = {}, std::unordered_map<const Net*, std::set<Gate*>>* cache = nullptr) const;
 
-        // test & document
+        /**
+         * Starting from the given gate, traverse the netlist and return only the next layer of sequential successor/predecessor gates.
+         * Traverse over gates that are not sequential until a sequential gate is found.
+         * Stops at all sequential gates, but only adds those to the result that have not been reached through a pin of one of the forbidden types.
+         * Provide a cache to speed up traversal when calling this function multiple times on the same netlist using the same forbidden pins.
+         * 
+         * @param[in] gate - Start gate.
+         * @param[in] successors - Set `true` to get successors, set `false` to get predecessors.
+         * @param[in] forbidden_pins - Sequential gates reached through these pins will not be part of the result. Defaults to an empty set.
+         * @param[in] cache - An optional cache that can be used for better performance on repeated calls. Defaults to a `nullptr`.
+         * @returns The next sequential gates.
+         */
         Result<std::set<Gate*>>
-            get_next_sequential_gates(const Gate* gate, bool successors, const std::set<PinType>& forbidden_input_pins = {}, std::unordered_map<const Net*, std::set<Gate*>>* cache = nullptr) const;
+            get_next_sequential_gates(const Gate* gate, bool successors, const std::set<PinType>& forbidden_pins = {}, std::unordered_map<const Net*, std::set<Gate*>>* cache = nullptr) const;
 
         // TODO implement get_next_combinational_gates (get all combinational successor gates until sequential (non-combinational) gates are hit)
 

--- a/include/hal_core/netlist/decorators/subgraph_netlist_decorator.h
+++ b/include/hal_core/netlist/decorators/subgraph_netlist_decorator.h
@@ -32,6 +32,11 @@
 
 namespace hal
 {
+    /**
+     * A netlist decorator that operates on an existing subgraph of the associated netlist to, e.g., copy the subgraph as a new netlist object or compute a Boolean function describing the subgraph.
+     *
+     * @ingroup decorators
+     */
     class NETLIST_API SubgraphNetlistDecorator
     {
     public:

--- a/include/hal_core/netlist/netlist.h
+++ b/include/hal_core/netlist/netlist.h
@@ -208,7 +208,7 @@ namespace hal
          * @param[in] gate - The gate to check.
          * @returns True if the gate is in the netlist, false otherwise.
          */
-        bool is_gate_in_netlist(Gate* gate) const;
+        bool is_gate_in_netlist(const Gate* gate) const;
 
         /**
          * Get the gate specified by the given ID.
@@ -342,7 +342,7 @@ namespace hal
          * @param[in] net - The net to check.
          * @returns True if the net is in the netlist, false otherwise.
          */
-        bool is_net_in_netlist(Net* net) const;
+        bool is_net_in_netlist(const Net* net) const;
 
         /**
          * Get the net specified by the given ID.
@@ -489,7 +489,7 @@ namespace hal
          * @param[in] module - The module to check.
          * @returns True if the module is in the netlist, false otherwise.
          */
-        bool is_module_in_netlist(Module* module) const;
+        bool is_module_in_netlist(const Module* module) const;
 
         /**
          * Get the module specified by the given ID.
@@ -568,7 +568,7 @@ namespace hal
          * @param[in] grouping - The grouping to check.
          * @returns True if the grouping is in the netlist, false otherwise.
          */
-        bool is_grouping_in_netlist(Grouping* grouping) const;
+        bool is_grouping_in_netlist(const Grouping* grouping) const;
 
         /**
          * Get the grouping specified by the given ID.
@@ -836,22 +836,22 @@ namespace hal
         /* stores the modules */
         Module* m_top_module;
         std::unordered_map<u32, std::unique_ptr<Module>> m_modules_map;
-        std::unordered_set<Module*> m_modules_set;
+        std::unordered_set<const Module*> m_modules_set;
         std::vector<Module*> m_modules;
 
         /* stores the nets */
         std::unordered_map<u32, std::unique_ptr<Net>> m_nets_map;
-        std::unordered_set<Net*> m_nets_set;
+        std::unordered_set<const Net*> m_nets_set;
         std::vector<Net*> m_nets;
 
         /* stores the gates */
         std::unordered_map<u32, std::unique_ptr<Gate>> m_gates_map;
-        std::unordered_set<Gate*> m_gates_set;
+        std::unordered_set<const Gate*> m_gates_set;
         std::vector<Gate*> m_gates;
 
         /* stores the groupings */
         std::unordered_map<u32, std::unique_ptr<Grouping>> m_groupings_map;
-        std::unordered_set<Grouping*> m_groupings_set;
+        std::unordered_set<const Grouping*> m_groupings_set;
         std::vector<Grouping*> m_groupings;
 
         /* stores the set of global gates and nets */

--- a/include/hal_core/netlist/netlist_utils.h
+++ b/include/hal_core/netlist/netlist_utils.h
@@ -98,6 +98,7 @@ namespace hal
             get_partial_netlist(const Netlist* nl, const std::vector<const Gate*>& subgraph_gates);
 
         /**
+         * \deprecated
          * Find predecessors or successors of a gate. If depth is set to 1 only direct predecessors/successors will be returned. 
          * Higher number of depth causes as many steps of recursive calls. 
          * If depth is set to 0 there is no limitation and the loop continues until no more predecessors/succesors are found.
@@ -110,9 +111,11 @@ namespace hal
          * @param[in] filter - User-defined filter function.
          * @return Vector of predecessor/successor gates.
          */
-        CORE_API std::vector<Gate*> get_next_gates(const Gate* gate, bool get_successors, int depth = 0, const std::function<bool(const Gate*)>& filter = nullptr);
+        [[deprecated("Will be removed in a future version, use NetlistTraversalDecorator::get_next_matching_gates_until_depth instead.")]] CORE_API std::vector<Gate*>
+            get_next_gates(const Gate* gate, bool get_successors, int depth = 0, const std::function<bool(const Gate*)>& filter = nullptr);
 
         /**
+         * \deprecated
          * Find predecessors or successors of a net. If depth is set to 1 only direct predecessors/successors will be returned. 
          * Higher number of depth causes as many steps of recursive calls. 
          * If depth is set to 0  there is no limitation and the loop continues until no more predecessors/succesors are found.
@@ -125,9 +128,11 @@ namespace hal
          * @param[in] filter - User-defined filter function.
          * @return Vector of predecessor/successor gates.
          */
-        CORE_API std::vector<Gate*> get_next_gates(const Net* net, bool get_successors, int depth = 0, const std::function<bool(const Gate*)>& filter = nullptr);
+        [[deprecated("Will be removed in a future version, use NetlistTraversalDecorator::get_next_matching_gates_until_depth instead.")]] CORE_API std::vector<Gate*>
+            get_next_gates(const Net* net, bool get_successors, int depth = 0, const std::function<bool(const Gate*)>& filter = nullptr);
 
         /**
+         * \deprecated
          * Find all sequential predecessors or successors of a gate.
          * Traverses combinational logic of all input or output nets until sequential gates are found.
          * The result may include the provided gate itself.
@@ -140,9 +145,11 @@ namespace hal
          * @param[inout] cache - The cache. 
          * @returns All sequential successors or predecessors of the gate.
          */
-        CORE_API std::vector<Gate*> get_next_sequential_gates(const Gate* gate, bool get_successors, std::unordered_map<u32, std::vector<Gate*>>& cache);
+        [[deprecated("Will be removed in a future version, use NetlistTraversalDecorator::get_next_sequential_gates instead.")]] CORE_API std::vector<Gate*>
+            get_next_sequential_gates(const Gate* gate, bool get_successors, std::unordered_map<u32, std::vector<Gate*>>& cache);
 
         /**
+         * \deprecated
          * Find all sequential predecessors or successors of a gate.
          * Traverses combinational logic of all input or output nets until sequential gates are found.
          * The result may include the provided gate itself.
@@ -151,9 +158,11 @@ namespace hal
          * @param[in] get_successors - If true, sequential successors are returned, otherwise sequential predecessors are returned.
          * @returns All sequential successors or predecessors of the gate.
          */
-        CORE_API std::vector<Gate*> get_next_sequential_gates(const Gate* gate, bool get_successors);
+        [[deprecated("Will be removed in a future version, use NetlistTraversalDecorator::get_next_sequential_gates instead.")]] CORE_API std::vector<Gate*>
+            get_next_sequential_gates(const Gate* gate, bool get_successors);
 
         /**
+         * \deprecated
          * Find all sequential predecessors or successors of a net.
          * Traverses combinational logic of all input or output nets until sequential gates are found.
          * The use of the cache is recommended in case of extensive usage of this function. 
@@ -165,9 +174,11 @@ namespace hal
          * @param[inout] cache - The cache. 
          * @returns All sequential successors or predecessors of the net.
          */
-        CORE_API std::vector<Gate*> get_next_sequential_gates(const Net* net, bool get_successors, std::unordered_map<u32, std::vector<Gate*>>& cache);
+        [[deprecated("Will be removed in a future version, use NetlistTraversalDecorator::get_next_sequential_gates instead.")]] CORE_API std::vector<Gate*>
+            get_next_sequential_gates(const Net* net, bool get_successors, std::unordered_map<u32, std::vector<Gate*>>& cache);
 
         /**
+         * \deprecated
          * Find all sequential predecessors or successors of a net.
          * Traverses combinational logic of all input or output nets until sequential gates are found.
          *
@@ -175,7 +186,8 @@ namespace hal
          * @param[in] get_successors - If true, sequential successors are returned, otherwise sequential predecessors are returned.
          * @returns All sequential successors or predecessors of the net.
          */
-        CORE_API std::vector<Gate*> get_next_sequential_gates(const Net* net, bool get_successors);
+        [[deprecated("Will be removed in a future version, use NetlistTraversalDecorator::get_next_sequential_gates instead.")]] CORE_API std::vector<Gate*>
+            get_next_sequential_gates(const Net* net, bool get_successors);
 
         /**
          * Find all gates on the predecessor or successor path of a gate.

--- a/include/hal_core/python_bindings/python_bindings.h
+++ b/include/hal_core/python_bindings/python_bindings.h
@@ -33,8 +33,9 @@
 #include "hal_core/netlist/boolean_function/types.h"
 #include "hal_core/netlist/decorators/boolean_function_decorator.h"
 #include "hal_core/netlist/decorators/boolean_function_net_decorator.h"
-#include "hal_core/netlist/decorators/subgraph_netlist_decorator.h"
 #include "hal_core/netlist/decorators/netlist_modification_decorator.h"
+#include "hal_core/netlist/decorators/netlist_traversal_decorator.h"
+#include "hal_core/netlist/decorators/subgraph_netlist_decorator.h"
 #include "hal_core/netlist/gate.h"
 #include "hal_core/netlist/gate_library/enums/async_set_reset_behavior.h"
 #include "hal_core/netlist/gate_library/gate_library.h"
@@ -318,6 +319,13 @@ namespace hal
      * @param[in] m - the python module
      */
     void netlist_modification_decorator_init(py::module& m);
+
+    /**
+     * Initializes Python bindings for the HAL netlist traversal decorator in a python module.
+     *
+     * @param[in] m - the python module
+     */
+    void netlist_traversal_decorator_init(py::module& m);
 
     /**
      * Initializes Python bindings for the HAL LogManager in a python module.

--- a/src/netlist/decorators/netlist_traversal_decorator.cpp
+++ b/src/netlist/decorators/netlist_traversal_decorator.cpp
@@ -274,6 +274,9 @@ namespace hal
                     // append cached gates to result
                     res.insert(cached_gates.begin(), cached_gates.end());
 
+                    // pop net from stack as it has been dealt with
+                    stack.pop_back();
+
                     continue;
                 }
             }

--- a/src/netlist/decorators/netlist_traversal_decorator.cpp
+++ b/src/netlist/decorators/netlist_traversal_decorator.cpp
@@ -481,4 +481,122 @@ namespace hal
 
         return OK(std::move(seq_gate_map));
     }
+
+    Result<std::set<Gate*>> NetlistTraversalDecorator::get_next_combinational_gates(const Net* net, bool successors, std::unordered_map<const Net*, std::set<Gate*>>* cache) const
+    {
+        if (net == nullptr)
+        {
+            return ERR("nullptr given as net");
+        }
+
+        if (!m_netlist.is_net_in_netlist(net))
+        {
+            return ERR("net does not belong to netlist");
+        }
+
+        std::unordered_set<const Net*> visited;
+        std::vector<const Net*> stack = {net};
+        std::vector<const Net*> previous;
+        std::set<Gate*> res;
+        while (!stack.empty())
+        {
+            const Net* current = stack.back();
+
+            if (!previous.empty() && current == previous.back())
+            {
+                stack.pop_back();
+                previous.pop_back();
+                continue;
+            }
+
+            visited.insert(current);
+
+            if (cache)
+            {
+                if (const auto it = cache->find(current); it != cache->end())
+                {
+                    const auto& cached_gates = std::get<1>(*it);
+
+                    // append cached gates to result
+                    res.insert(cached_gates.begin(), cached_gates.end());
+
+                    // pop net from stack as it has been dealt with
+                    stack.pop_back();
+
+                    continue;
+                }
+            }
+
+            bool added = false;
+            for (const auto* entry_ep : successors ? current->get_destinations() : current->get_sources())
+            {
+                auto* gate = entry_ep->get_gate();
+                if (!gate->get_type()->has_property(GateTypeProperty::combinational))
+                {
+                    // stop traversal if not combinational
+                    continue;
+                }
+
+                // add to result if gate is combinational
+                res.insert(gate);
+
+                // update cache
+                if (cache)
+                {
+                    (*cache)[current].insert(gate);
+                    for (const auto* n : previous)
+                    {
+                        (*cache)[n].insert(gate);
+                    }
+                }
+
+                for (const auto* exit_ep : successors ? gate->get_fan_out_endpoints() : gate->get_fan_in_endpoints())
+                {
+                    const Net* n = exit_ep->get_net();
+                    if (visited.find(n) == visited.end())
+                    {
+                        stack.push_back(n);
+                        added = true;
+                    }
+                }
+            }
+
+            if (added)
+            {
+                previous.push_back(current);
+            }
+            else
+            {
+                stack.pop_back();
+            }
+        }
+
+        return OK(res);
+    }
+
+    Result<std::set<Gate*>> NetlistTraversalDecorator::get_next_combinational_gates(const Gate* gate, bool successors, std::unordered_map<const Net*, std::set<Gate*>>* cache) const
+    {
+        if (gate == nullptr)
+        {
+            return ERR("nullptr given as gate");
+        }
+
+        if (!m_netlist.is_gate_in_netlist(gate))
+        {
+            return ERR("net does not belong to netlist");
+        }
+
+        std::set<Gate*> res;
+        for (const auto* exit_ep : successors ? gate->get_fan_out_endpoints() : gate->get_fan_in_endpoints())
+        {
+            const auto next_res = this->get_next_combinational_gates(exit_ep->get_net(), successors, cache);
+            if (next_res.is_error())
+            {
+                return ERR(next_res.get_error());
+            }
+            auto next = next_res.get();
+            res.insert(next.begin(), next.end());
+        }
+        return OK(res);
+    }
 }    // namespace hal

--- a/src/netlist/decorators/netlist_traversal_decorator.cpp
+++ b/src/netlist/decorators/netlist_traversal_decorator.cpp
@@ -235,10 +235,8 @@ namespace hal
         return OK(res);
     }
 
-    Result<std::set<Gate*>> NetlistTraversalDecorator::get_next_sequential_gates(const Net* net,
-                                                                                 bool successors,
-                                                                                 const std::set<PinType>& forbidden_input_pins,
-                                                                                 std::unordered_map<const Net*, std::set<Gate*>>* cache) const
+    Result<std::set<Gate*>>
+        NetlistTraversalDecorator::get_next_sequential_gates(const Net* net, bool successors, const std::set<PinType>& forbidden_pins, std::unordered_map<const Net*, std::set<Gate*>>* cache) const
     {
         if (net == nullptr)
         {
@@ -289,7 +287,7 @@ namespace hal
                 if (gate->get_type()->has_property(GateTypeProperty::sequential))
                 {
                     // stop traversal if gate is sequential
-                    if (forbidden_input_pins.find(pin->get_type()) == forbidden_input_pins.end())
+                    if (forbidden_pins.find(pin->get_type()) == forbidden_pins.end())
                     {
                         // only add gate to result if it has not been reached through a forbidden pin (e.g., control pin)
                         res.insert(gate);
@@ -332,10 +330,8 @@ namespace hal
         return OK(res);
     }
 
-    Result<std::set<Gate*>> NetlistTraversalDecorator::get_next_sequential_gates(const Gate* gate,
-                                                                                 bool successors,
-                                                                                 const std::set<PinType>& forbidden_input_pins,
-                                                                                 std::unordered_map<const Net*, std::set<Gate*>>* cache) const
+    Result<std::set<Gate*>>
+        NetlistTraversalDecorator::get_next_sequential_gates(const Gate* gate, bool successors, const std::set<PinType>& forbidden_pins, std::unordered_map<const Net*, std::set<Gate*>>* cache) const
     {
         if (gate == nullptr)
         {
@@ -350,7 +346,7 @@ namespace hal
         std::set<Gate*> res;
         for (const auto* exit_ep : successors ? gate->get_fan_out_endpoints() : gate->get_fan_in_endpoints())
         {
-            const auto next_res = this->get_next_sequential_gates(exit_ep->get_net(), successors, forbidden_input_pins, cache);
+            const auto next_res = this->get_next_sequential_gates(exit_ep->get_net(), successors, forbidden_pins, cache);
             if (next_res.is_error())
             {
                 return ERR(next_res.get_error());

--- a/src/netlist/decorators/netlist_traversal_decorator.cpp
+++ b/src/netlist/decorators/netlist_traversal_decorator.cpp
@@ -12,6 +12,7 @@ namespace hal
     Result<std::set<Gate*>> NetlistTraversalDecorator::get_next_matching_gates(const Net* net,
                                                                                bool successors,
                                                                                const std::function<bool(const Gate*)>& target_gate_filter,
+                                                                               bool continue_on_match,
                                                                                const std::function<bool(const Endpoint*, u32 current_depth)>& exit_endpoint_filter,
                                                                                const std::function<bool(const Endpoint*, u32 current_depth)>& entry_endpoint_filter) const
     {
@@ -23,6 +24,135 @@ namespace hal
         if (!m_netlist.is_net_in_netlist(net))
         {
             return ERR("net does not belong to netlist");
+        }
+
+        if (!target_gate_filter)
+        {
+            return ERR("no target gate filter specified");
+        }
+
+        std::unordered_set<const Net*> visited;
+        std::vector<const Net*> stack = {net};
+        std::vector<const Net*> previous;
+        std::set<Gate*> res;
+        while (!stack.empty())
+        {
+            const Net* current = stack.back();
+
+            if (!previous.empty() && current == previous.back())
+            {
+                stack.pop_back();
+                previous.pop_back();
+                continue;
+            }
+
+            visited.insert(current);
+
+            bool added = false;
+            for (const auto* entry_ep : successors ? current->get_destinations() : current->get_sources())
+            {
+                if (entry_endpoint_filter != nullptr && !entry_endpoint_filter(entry_ep, previous.size() + 1))
+                {
+                    continue;
+                }
+
+                auto* g = entry_ep->get_gate();
+
+                if (target_gate_filter(g))
+                {
+                    res.insert(g);
+
+                    if (!continue_on_match)
+                    {
+                        continue;
+                    }
+                }
+
+                for (const auto* exit_ep : successors ? g->get_fan_out_endpoints() : g->get_fan_in_endpoints())
+                {
+                    if (exit_endpoint_filter != nullptr && !exit_endpoint_filter(exit_ep, previous.size() + 1))
+                    {
+                        continue;
+                    }
+
+                    const Net* n = exit_ep->get_net();
+                    if (visited.find(n) == visited.end())
+                    {
+                        stack.push_back(n);
+                        added = true;
+                    }
+                }
+            }
+
+            if (added)
+            {
+                previous.push_back(current);
+            }
+            else
+            {
+                stack.pop_back();
+            }
+        }
+
+        return OK(res);
+    }
+
+    Result<std::set<Gate*>> NetlistTraversalDecorator::get_next_matching_gates(const Gate* gate,
+                                                                               bool successors,
+                                                                               const std::function<bool(const Gate*)>& target_gate_filter,
+                                                                               bool continue_on_match,
+                                                                               const std::function<bool(const Endpoint*, u32 current_depth)>& exit_endpoint_filter,
+                                                                               const std::function<bool(const Endpoint*, u32 current_depth)>& entry_endpoint_filter) const
+    {
+        if (gate == nullptr)
+        {
+            return ERR("nullptr given as gate");
+        }
+
+        if (!m_netlist.is_gate_in_netlist(gate))
+        {
+            return ERR("net does not belong to netlist");
+        }
+
+        std::set<Gate*> res;
+        for (const auto* exit_ep : successors ? gate->get_fan_out_endpoints() : gate->get_fan_in_endpoints())
+        {
+            if (exit_endpoint_filter != nullptr && !exit_endpoint_filter(exit_ep, 0))
+            {
+                continue;
+            }
+
+            const auto next_res = this->get_next_matching_gates(exit_ep->get_net(), successors, target_gate_filter, continue_on_match, exit_endpoint_filter, entry_endpoint_filter);
+            if (next_res.is_error())
+            {
+                return ERR(next_res.get_error());
+            }
+            auto next = next_res.get();
+            res.insert(next.begin(), next.end());
+        }
+        return OK(res);
+    }
+
+    Result<std::set<Gate*>> NetlistTraversalDecorator::get_next_matching_gates_until(const Net* net,
+                                                                                     bool successors,
+                                                                                     const std::function<bool(const Gate*)>& target_gate_filter,
+                                                                                     bool continue_on_mismatch,
+                                                                                     const std::function<bool(const Endpoint*, u32 current_depth)>& exit_endpoint_filter,
+                                                                                     const std::function<bool(const Endpoint*, u32 current_depth)>& entry_endpoint_filter) const
+    {
+        if (net == nullptr)
+        {
+            return ERR("nullptr given as net");
+        }
+
+        if (!m_netlist.is_net_in_netlist(net))
+        {
+            return ERR("net does not belong to netlist");
+        }
+
+        if (!target_gate_filter)
+        {
+            return ERR("no target gate filter specified");
         }
 
         std::unordered_set<const Net*> visited;
@@ -58,117 +188,10 @@ namespace hal
                 }
                 else
                 {
-                    for (const auto* exit_ep : successors ? g->get_fan_out_endpoints() : g->get_fan_in_endpoints())
+                    if (!continue_on_mismatch)
                     {
-                        if (exit_endpoint_filter != nullptr && !exit_endpoint_filter(exit_ep, previous.size() + 1))
-                        {
-                            continue;
-                        }
-
-                        const Net* n = exit_ep->get_net();
-                        if (visited.find(n) == visited.end())
-                        {
-                            stack.push_back(n);
-                            added = true;
-                        }
+                        continue;
                     }
-                }
-            }
-
-            if (added)
-            {
-                previous.push_back(current);
-            }
-            else
-            {
-                stack.pop_back();
-            }
-        }
-
-        return OK(res);
-    }
-
-    Result<std::set<Gate*>> NetlistTraversalDecorator::get_next_matching_gates(const Gate* gate,
-                                                                               bool successors,
-                                                                               const std::function<bool(const Gate*)>& target_gate_filter,
-                                                                               const std::function<bool(const Endpoint*, u32 current_depth)>& exit_endpoint_filter,
-                                                                               const std::function<bool(const Endpoint*, u32 current_depth)>& entry_endpoint_filter) const
-    {
-        if (gate == nullptr)
-        {
-            return ERR("nullptr given as gate");
-        }
-
-        if (!m_netlist.is_gate_in_netlist(gate))
-        {
-            return ERR("net does not belong to netlist");
-        }
-
-        std::set<Gate*> res;
-        for (const auto* exit_ep : successors ? gate->get_fan_out_endpoints() : gate->get_fan_in_endpoints())
-        {
-            if (exit_endpoint_filter != nullptr && !exit_endpoint_filter(exit_ep, 0))
-            {
-                continue;
-            }
-
-            const auto next_res = this->get_next_matching_gates(exit_ep->get_net(), successors, target_gate_filter, exit_endpoint_filter, entry_endpoint_filter);
-            if (next_res.is_error())
-            {
-                return ERR(next_res.get_error());
-            }
-            auto next = next_res.get();
-            res.insert(next.begin(), next.end());
-        }
-        return OK(res);
-    }
-
-    Result<std::set<Gate*>> NetlistTraversalDecorator::get_next_matching_gates_until(const Net* net,
-                                                                                     bool successors,
-                                                                                     const std::function<bool(const Gate*)>& target_gate_filter,
-                                                                                     const std::function<bool(const Endpoint*, u32 current_depth)>& exit_endpoint_filter,
-                                                                                     const std::function<bool(const Endpoint*, u32 current_depth)>& entry_endpoint_filter) const
-    {
-        if (net == nullptr)
-        {
-            return ERR("nullptr given as net");
-        }
-
-        if (!m_netlist.is_net_in_netlist(net))
-        {
-            return ERR("net does not belong to netlist");
-        }
-
-        std::unordered_set<const Net*> visited;
-        std::vector<const Net*> stack = {net};
-        std::vector<const Net*> previous;
-        std::set<Gate*> res;
-        while (!stack.empty())
-        {
-            const Net* current = stack.back();
-
-            if (!previous.empty() && current == previous.back())
-            {
-                stack.pop_back();
-                previous.pop_back();
-                continue;
-            }
-
-            visited.insert(current);
-
-            bool added = false;
-            for (const auto* entry_ep : successors ? current->get_destinations() : current->get_sources())
-            {
-                if (entry_endpoint_filter != nullptr && !entry_endpoint_filter(entry_ep, previous.size() + 1))
-                {
-                    continue;
-                }
-
-                auto* g = entry_ep->get_gate();
-
-                if ((target_gate_filter == nullptr) || target_gate_filter(g))
-                {
-                    res.insert(g);
                 }
 
                 for (const auto* exit_ep : successors ? g->get_fan_out_endpoints() : g->get_fan_in_endpoints())
@@ -203,6 +226,7 @@ namespace hal
     Result<std::set<Gate*>> NetlistTraversalDecorator::get_next_matching_gates_until(const Gate* gate,
                                                                                      bool successors,
                                                                                      const std::function<bool(const Gate*)>& target_gate_filter,
+                                                                                     bool continue_on_mismatch,
                                                                                      const std::function<bool(const Endpoint*, u32 current_depth)>& exit_endpoint_filter,
                                                                                      const std::function<bool(const Endpoint*, u32 current_depth)>& entry_endpoint_filter) const
     {
@@ -224,7 +248,7 @@ namespace hal
                 continue;
             }
 
-            const auto next_res = this->get_next_matching_gates_until(exit_ep->get_net(), successors, target_gate_filter, exit_endpoint_filter, entry_endpoint_filter);
+            const auto next_res = this->get_next_matching_gates_until(exit_ep->get_net(), successors, target_gate_filter, continue_on_mismatch, exit_endpoint_filter, entry_endpoint_filter);
             if (next_res.is_error())
             {
                 return ERR(next_res.get_error());
@@ -236,7 +260,7 @@ namespace hal
     }
 
     Result<std::set<Gate*>>
-        NetlistTraversalDecorator::get_next_matching_gates_until_depth(const Net* net, bool successors, const std::function<bool(const Gate*)>& target_gate_filter, u32 max_depth) const
+        NetlistTraversalDecorator::get_next_matching_gates_until_depth(const Net* net, bool successors, u32 max_depth, const std::function<bool(const Gate*)>& target_gate_filter) const
     {
         if (net == nullptr)
         {
@@ -311,7 +335,7 @@ namespace hal
     }
 
     Result<std::set<Gate*>>
-        NetlistTraversalDecorator::get_next_matching_gates_until_depth(const Gate* gate, bool successors, const std::function<bool(const Gate*)>& target_gate_filter, u32 max_depth) const
+        NetlistTraversalDecorator::get_next_matching_gates_until_depth(const Gate* gate, bool successors, u32 max_depth, const std::function<bool(const Gate*)>& target_gate_filter) const
     {
         if (gate == nullptr)
         {
@@ -326,7 +350,7 @@ namespace hal
         std::set<Gate*> res;
         for (const auto* exit_ep : successors ? gate->get_fan_out_endpoints() : gate->get_fan_in_endpoints())
         {
-            const auto next_res = this->get_next_matching_gates_until_depth(exit_ep->get_net(), successors, target_gate_filter, max_depth);
+            const auto next_res = this->get_next_matching_gates_until_depth(exit_ep->get_net(), successors, max_depth, target_gate_filter);
             if (next_res.is_error())
             {
                 return ERR(next_res.get_error());

--- a/src/netlist/decorators/netlist_traversal_decorator.cpp
+++ b/src/netlist/decorators/netlist_traversal_decorator.cpp
@@ -359,4 +359,24 @@ namespace hal
         }
         return OK(res);
     }
+
+    Result<std::map<Gate*, std::set<Gate*>>> NetlistTraversalDecorator::get_next_sequential_gates_map(bool successors, const std::set<PinType>& forbidden_pins) const
+    {
+        std::map<Gate*, std::set<Gate*>> seq_gate_map;
+        std::unordered_map<const Net*, std::set<Gate*>> cache = {};
+
+        for (auto* sg : m_netlist.get_gates([](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::sequential); }))
+        {
+            if (const auto res = this->get_next_sequential_gates(sg, successors, forbidden_pins, &cache); res.is_ok())
+            {
+                seq_gate_map[sg] = res.get();
+            }
+            else
+            {
+                return ERR(res.get_error());
+            }
+        }
+
+        return OK(std::move(seq_gate_map));
+    }
 }    // namespace hal

--- a/src/netlist/decorators/netlist_traversal_decorator.cpp
+++ b/src/netlist/decorators/netlist_traversal_decorator.cpp
@@ -1,0 +1,237 @@
+#include "hal_core/netlist/decorators/netlist_traversal_decorator.h"
+
+#include "hal_core/netlist/gate.h"
+#include "hal_core/netlist/net.h"
+
+namespace hal
+{
+    NetlistTraversalDecorator::NetlistTraversalDecorator(const Netlist& netlist) : m_netlist(netlist)
+    {
+    }
+
+    Result<std::set<Gate*>> NetlistTraversalDecorator::get_next_matching_gates(const Net* net,
+                                                                               bool successors,
+                                                                               const std::function<bool(const Gate*)>& target_gate_filter,
+                                                                               const std::function<bool(const Endpoint*, u32 current_depth)>& exit_endpoint_filter,
+                                                                               const std::function<bool(const Endpoint*, u32 current_depth)>& entry_endpoint_filter) const
+    {
+        if (net == nullptr)
+        {
+            return ERR("nullptr given as net");
+        }
+
+        if (!m_netlist.is_net_in_netlist(net))
+        {
+            return ERR("net does not belong to netlist");
+        }
+
+        std::unordered_set<const Net*> visited;
+        std::vector<const Net*> stack = {net};
+        std::vector<const Net*> previous;
+        std::set<Gate*> res;
+        while (!stack.empty())
+        {
+            const Net* current = stack.back();
+
+            if (!previous.empty() && current == previous.back())
+            {
+                stack.pop_back();
+                previous.pop_back();
+                continue;
+            }
+
+            visited.insert(current);
+
+            bool added = false;
+            for (const auto* entry_ep : successors ? current->get_destinations() : current->get_sources())
+            {
+                if (entry_endpoint_filter != nullptr && !entry_endpoint_filter(entry_ep, previous.size() + 1))
+                {
+                    continue;
+                }
+
+                auto* g = entry_ep->get_gate();
+
+                if (target_gate_filter(g))
+                {
+                    res.insert(g);
+                }
+                else
+                {
+                    for (const auto* exit_ep : successors ? g->get_fan_out_endpoints() : g->get_fan_in_endpoints())
+                    {
+                        if (exit_endpoint_filter != nullptr && !exit_endpoint_filter(exit_ep, previous.size() + 1))
+                        {
+                            continue;
+                        }
+
+                        const Net* n = exit_ep->get_net();
+                        if (visited.find(n) == visited.end())
+                        {
+                            stack.push_back(n);
+                            added = true;
+                        }
+                    }
+                }
+            }
+
+            if (added)
+            {
+                previous.push_back(current);
+            }
+            else
+            {
+                stack.pop_back();
+            }
+        }
+
+        return OK(res);
+    }
+
+    Result<std::set<Gate*>> NetlistTraversalDecorator::get_next_matching_gates(const Gate* gate,
+                                                                               bool successors,
+                                                                               const std::function<bool(const Gate*)>& target_gate_filter,
+                                                                               const std::function<bool(const Endpoint*, u32 current_depth)>& exit_endpoint_filter,
+                                                                               const std::function<bool(const Endpoint*, u32 current_depth)>& entry_endpoint_filter) const
+    {
+        if (gate == nullptr)
+        {
+            return ERR("nullptr given as gate");
+        }
+
+        if (!m_netlist.is_gate_in_netlist(gate))
+        {
+            return ERR("net does not belong to netlist");
+        }
+
+        std::set<Gate*> res;
+        for (const auto* exit_ep : successors ? gate->get_fan_out_endpoints() : gate->get_fan_in_endpoints())
+        {
+            if (exit_endpoint_filter != nullptr && !exit_endpoint_filter(exit_ep, 0))
+            {
+                continue;
+            }
+
+            const auto next_res = this->get_next_matching_gates(exit_ep->get_net(), successors, target_gate_filter, exit_endpoint_filter, entry_endpoint_filter);
+            if (next_res.is_error())
+            {
+                return ERR(next_res.get_error());
+            }
+            auto next = next_res.get();
+            res.insert(next.begin(), next.end());
+        }
+        return OK(res);
+    }
+
+    Result<std::set<Gate*>> NetlistTraversalDecorator::get_next_matching_gates_until(const Net* net,
+                                                                                     bool successors,
+                                                                                     const std::function<bool(const Gate*)>& target_gate_filter,
+                                                                                     const std::function<bool(const Endpoint*, u32 current_depth)>& exit_endpoint_filter,
+                                                                                     const std::function<bool(const Endpoint*, u32 current_depth)>& entry_endpoint_filter) const
+    {
+        if (net == nullptr)
+        {
+            return ERR("nullptr given as net");
+        }
+
+        if (!m_netlist.is_net_in_netlist(net))
+        {
+            return ERR("net does not belong to netlist");
+        }
+
+        std::unordered_set<const Net*> visited;
+        std::vector<const Net*> stack = {net};
+        std::vector<const Net*> previous;
+        std::set<Gate*> res;
+        while (!stack.empty())
+        {
+            const Net* current = stack.back();
+
+            if (!previous.empty() && current == previous.back())
+            {
+                stack.pop_back();
+                previous.pop_back();
+                continue;
+            }
+
+            visited.insert(current);
+
+            bool added = false;
+            for (const auto* entry_ep : successors ? current->get_destinations() : current->get_sources())
+            {
+                if (entry_endpoint_filter != nullptr && !entry_endpoint_filter(entry_ep, previous.size() + 1))
+                {
+                    continue;
+                }
+
+                auto* g = entry_ep->get_gate();
+
+                if ((target_gate_filter == nullptr) || target_gate_filter(g))
+                {
+                    res.insert(g);
+                }
+
+                for (const auto* exit_ep : successors ? g->get_fan_out_endpoints() : g->get_fan_in_endpoints())
+                {
+                    if (exit_endpoint_filter != nullptr && !exit_endpoint_filter(exit_ep, previous.size() + 1))
+                    {
+                        continue;
+                    }
+
+                    const Net* n = exit_ep->get_net();
+                    if (visited.find(n) == visited.end())
+                    {
+                        stack.push_back(n);
+                        added = true;
+                    }
+                }
+            }
+
+            if (added)
+            {
+                previous.push_back(current);
+            }
+            else
+            {
+                stack.pop_back();
+            }
+        }
+
+        return OK(res);
+    }
+
+    Result<std::set<Gate*>> NetlistTraversalDecorator::get_next_matching_gates_until(const Gate* gate,
+                                                                                     bool successors,
+                                                                                     const std::function<bool(const Gate*)>& target_gate_filter,
+                                                                                     const std::function<bool(const Endpoint*, u32 current_depth)>& exit_endpoint_filter,
+                                                                                     const std::function<bool(const Endpoint*, u32 current_depth)>& entry_endpoint_filter) const
+    {
+        if (gate == nullptr)
+        {
+            return ERR("nullptr given as gate");
+        }
+
+        if (!m_netlist.is_gate_in_netlist(gate))
+        {
+            return ERR("net does not belong to netlist");
+        }
+
+        std::set<Gate*> res;
+        for (const auto* exit_ep : successors ? gate->get_fan_out_endpoints() : gate->get_fan_in_endpoints())
+        {
+            if (exit_endpoint_filter != nullptr && !exit_endpoint_filter(exit_ep, 0))
+            {
+                continue;
+            }
+
+            const auto next_res = this->get_next_matching_gates_until(exit_ep->get_net(), successors, target_gate_filter, exit_endpoint_filter, entry_endpoint_filter);
+            if (next_res.is_error())
+            {
+                return ERR(next_res.get_error());
+            }
+            auto next = next_res.get();
+            res.insert(next.begin(), next.end());
+        }
+        return OK(res);
+    }
+}    // namespace hal

--- a/src/netlist/decorators/netlist_traversal_decorator.cpp
+++ b/src/netlist/decorators/netlist_traversal_decorator.cpp
@@ -234,4 +234,130 @@ namespace hal
         }
         return OK(res);
     }
+
+    Result<std::set<Gate*>> NetlistTraversalDecorator::get_next_sequential_gates(const Net* net,
+                                                                                 bool successors,
+                                                                                 const std::set<PinType>& forbidden_input_pins,
+                                                                                 std::unordered_map<const Net*, std::set<Gate*>>* cache) const
+    {
+        if (net == nullptr)
+        {
+            return ERR("nullptr given as net");
+        }
+
+        if (!m_netlist.is_net_in_netlist(net))
+        {
+            return ERR("net does not belong to netlist");
+        }
+
+        std::unordered_set<const Net*> visited;
+        std::vector<const Net*> stack = {net};
+        std::vector<const Net*> previous;
+        std::set<Gate*> res;
+        while (!stack.empty())
+        {
+            const Net* current = stack.back();
+
+            if (!previous.empty() && current == previous.back())
+            {
+                stack.pop_back();
+                previous.pop_back();
+                continue;
+            }
+
+            visited.insert(current);
+
+            if (cache)
+            {
+                if (const auto it = cache->find(current); it != cache->end())
+                {
+                    const auto& cached_gates = std::get<1>(*it);
+
+                    // append cached gates to result
+                    res.insert(cached_gates.begin(), cached_gates.end());
+
+                    continue;
+                }
+            }
+
+            bool added = false;
+            for (const auto* entry_ep : successors ? current->get_destinations() : current->get_sources())
+            {
+                auto pin   = entry_ep->get_pin();
+                auto* gate = entry_ep->get_gate();
+
+                if (gate->get_type()->has_property(GateTypeProperty::sequential))
+                {
+                    // stop traversal if gate is sequential
+                    if (forbidden_input_pins.find(pin->get_type()) == forbidden_input_pins.end())
+                    {
+                        // only add gate to result if it has not been reached through a forbidden pin (e.g., control pin)
+                        res.insert(gate);
+
+                        // update cache
+                        if (cache)
+                        {
+                            (*cache)[current].insert(gate);
+                            for (const auto* n : previous)
+                            {
+                                (*cache)[n].insert(gate);
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    for (const auto* exit_ep : successors ? gate->get_fan_out_endpoints() : gate->get_fan_in_endpoints())
+                    {
+                        const Net* n = exit_ep->get_net();
+                        if (visited.find(n) == visited.end())
+                        {
+                            stack.push_back(n);
+                            added = true;
+                        }
+                    }
+                }
+            }
+
+            if (added)
+            {
+                previous.push_back(current);
+            }
+            else
+            {
+                stack.pop_back();
+            }
+        }
+
+        return OK(res);
+    }
+
+    Result<std::set<Gate*>> NetlistTraversalDecorator::get_next_sequential_gates(const Gate* gate,
+                                                                                 bool successors,
+                                                                                 const std::set<PinType>& forbidden_input_pins,
+                                                                                 std::unordered_map<const Net*, std::set<Gate*>>* cache) const
+    {
+        if (gate == nullptr)
+        {
+            return ERR("nullptr given as gate");
+        }
+
+        if (!m_netlist.is_gate_in_netlist(gate))
+        {
+            return ERR("net does not belong to netlist");
+        }
+
+        std::set<Gate*> res;
+        for (const auto* exit_ep : successors ? gate->get_fan_out_endpoints() : gate->get_fan_in_endpoints())
+        {
+            const auto next_res = this->get_next_sequential_gates(exit_ep->get_net(), successors, forbidden_input_pins, cache);
+            if (next_res.is_error())
+            {
+                return ERR(next_res.get_error());
+            }
+            auto next = next_res.get();
+            res.insert(next.begin(), next.end());
+        }
+        return OK(res);
+    }
 }    // namespace hal

--- a/src/netlist/decorators/netlist_traversal_decorator.cpp
+++ b/src/netlist/decorators/netlist_traversal_decorator.cpp
@@ -236,6 +236,108 @@ namespace hal
     }
 
     Result<std::set<Gate*>>
+        NetlistTraversalDecorator::get_next_matching_gates_until_depth(const Net* net, bool successors, const std::function<bool(const Gate*)>& target_gate_filter, u32 max_depth) const
+    {
+        if (net == nullptr)
+        {
+            return ERR("nullptr given as net");
+        }
+
+        if (!m_netlist.is_net_in_netlist(net))
+        {
+            return ERR("net does not belong to netlist");
+        }
+
+        std::unordered_set<const Net*> visited;
+        std::vector<const Net*> stack = {net};
+        std::vector<const Net*> previous;
+        std::set<Gate*> res;
+        while (!stack.empty())
+        {
+            const Net* current = stack.back();
+
+            if (!previous.empty() && current == previous.back())
+            {
+                stack.pop_back();
+                previous.pop_back();
+                continue;
+            }
+
+            u32 current_depth = previous.size() + 1;
+            visited.insert(current);
+
+            bool added = false;
+            for (const auto* entry_ep : successors ? current->get_destinations() : current->get_sources())
+            {
+                if (max_depth != 0 && current_depth > max_depth)
+                {
+                    continue;
+                }
+
+                auto* g = entry_ep->get_gate();
+
+                if ((target_gate_filter == nullptr) || target_gate_filter(g))
+                {
+                    res.insert(g);
+                }
+
+                for (const auto* exit_ep : successors ? g->get_fan_out_endpoints() : g->get_fan_in_endpoints())
+                {
+                    if (max_depth != 0 && current_depth == max_depth)
+                    {
+                        continue;
+                    }
+
+                    const Net* n = exit_ep->get_net();
+                    if (visited.find(n) == visited.end())
+                    {
+                        stack.push_back(n);
+                        added = true;
+                    }
+                }
+            }
+
+            if (added)
+            {
+                previous.push_back(current);
+            }
+            else
+            {
+                stack.pop_back();
+            }
+        }
+
+        return OK(res);
+    }
+
+    Result<std::set<Gate*>>
+        NetlistTraversalDecorator::get_next_matching_gates_until_depth(const Gate* gate, bool successors, const std::function<bool(const Gate*)>& target_gate_filter, u32 max_depth) const
+    {
+        if (gate == nullptr)
+        {
+            return ERR("nullptr given as gate");
+        }
+
+        if (!m_netlist.is_gate_in_netlist(gate))
+        {
+            return ERR("net does not belong to netlist");
+        }
+
+        std::set<Gate*> res;
+        for (const auto* exit_ep : successors ? gate->get_fan_out_endpoints() : gate->get_fan_in_endpoints())
+        {
+            const auto next_res = this->get_next_matching_gates_until_depth(exit_ep->get_net(), successors, target_gate_filter, max_depth);
+            if (next_res.is_error())
+            {
+                return ERR(next_res.get_error());
+            }
+            auto next = next_res.get();
+            res.insert(next.begin(), next.end());
+        }
+        return OK(res);
+    }
+
+    Result<std::set<Gate*>>
         NetlistTraversalDecorator::get_next_sequential_gates(const Net* net, bool successors, const std::set<PinType>& forbidden_pins, std::unordered_map<const Net*, std::set<Gate*>>* cache) const
     {
         if (net == nullptr)

--- a/src/netlist/netlist.cpp
+++ b/src/netlist/netlist.cpp
@@ -185,7 +185,7 @@ namespace hal
         return m_manager->delete_gate(gate);
     }
 
-    bool Netlist::is_gate_in_netlist(Gate* gate) const
+    bool Netlist::is_gate_in_netlist(const Gate* gate) const
     {
         return gate != nullptr && m_gates_set.find(gate) != m_gates_set.end();
     }
@@ -345,7 +345,7 @@ namespace hal
         return m_manager->delete_net(n);
     }
 
-    bool Netlist::is_net_in_netlist(Net* n) const
+    bool Netlist::is_net_in_netlist(const Net* n) const
     {
         return n != nullptr && m_nets_set.find(n) != m_nets_set.end();
     }
@@ -610,7 +610,7 @@ namespace hal
         return res;
     }
 
-    bool Netlist::is_module_in_netlist(Module* module) const
+    bool Netlist::is_module_in_netlist(const Module* module) const
     {
         return (module != nullptr) && (m_modules_set.find(module) != m_modules_set.end());
     }
@@ -649,7 +649,7 @@ namespace hal
         return m_manager->delete_grouping(g);
     }
 
-    bool Netlist::is_grouping_in_netlist(Grouping* n) const
+    bool Netlist::is_grouping_in_netlist(const Grouping* n) const
     {
         return n != nullptr && m_groupings_set.find(n) != m_groupings_set.end();
     }
@@ -667,7 +667,7 @@ namespace hal
 
     const std::vector<Grouping*>& Netlist::get_groupings() const
     {
-        return m_groupings;  
+        return m_groupings;
     }
 
     std::vector<Grouping*> Netlist::get_groupings(const std::function<bool(const Grouping*)>& filter) const

--- a/src/python_bindings/bindings/netlist_traversal_decorator.cpp
+++ b/src/python_bindings/bindings/netlist_traversal_decorator.cpp
@@ -282,39 +282,6 @@ namespace hal
 
         py_netlist_traversal_decorator.def(
             "get_next_sequential_gates",
-            [](NetlistTraversalDecorator& self, const Net* net, bool successors, const std::set<PinType>& forbidden_pins, std::unordered_map<const Net*, std::set<Gate*>>* cache)
-                -> std::optional<std::set<Gate*>> {
-                auto res = self.get_next_sequential_gates(net, successors, forbidden_pins, cache);
-                if (res.is_ok())
-                {
-                    return res.get();
-                }
-                else
-                {
-                    log_error("python_context", "error encountered while getting next sequential gates:\n{}", res.get_error().get());
-                    return std::nullopt;
-                }
-            },
-            py::arg("net"),
-            py::arg("successors"),
-            py::arg("forbidden_pins"),
-            py::arg("cache"),
-            R"(
-            Starting from the given net, traverse the netlist and return only the next layer of sequential successor/predecessor gates.
-            Traverse over gates that are not sequential until a sequential gate is found.
-            Stop traversal at all sequential gates, but only adds those to the result that have not been reached through a pin of one of the forbidden types.
-            Provide a cache to speed up traversal when calling this function multiple times on the same netlist using the same forbidden pins.
-
-            :param hal_py.Net net: Start net.
-            :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
-            :param set[hal_py.PinType] forbidden_pins: Sequential gates reached through these pins will not be part of the result.
-            :param dict[hal_py.Net, set[hal_py.Gate]] cache: A cache that can be used for better performance on repeated calls.
-            :returns: The next sequential gates on success, ``None`` otherwise.
-            :rtype: set[hal_py.Gate] or None
-        )");
-
-        py_netlist_traversal_decorator.def(
-            "get_next_sequential_gates",
             [](NetlistTraversalDecorator& self, const Gate* gate, bool successors, const std::set<PinType>& forbidden_pins) -> std::optional<std::set<Gate*>> {
                 auto res = self.get_next_sequential_gates(gate, successors, forbidden_pins, nullptr);
                 if (res.is_ok())
@@ -338,39 +305,6 @@ namespace hal
             :param hal_py.Gate gate: Start gate.
             :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
             :param set[hal_py.PinType] forbidden_pins: Sequential gates reached through these pins will not be part of the result.
-            :returns: The next sequential gates on success, ``None`` otherwise.
-            :rtype: set[hal_py.Gate] or None
-        )");
-
-        py_netlist_traversal_decorator.def(
-            "get_next_sequential_gates",
-            [](NetlistTraversalDecorator& self, const Gate* gate, bool successors, const std::set<PinType>& forbidden_pins, std::unordered_map<const Net*, std::set<Gate*>>* cache)
-                -> std::optional<std::set<Gate*>> {
-                auto res = self.get_next_sequential_gates(gate, successors, forbidden_pins, cache);
-                if (res.is_ok())
-                {
-                    return res.get();
-                }
-                else
-                {
-                    log_error("python_context", "error encountered while getting next sequential gates:\n{}", res.get_error().get());
-                    return std::nullopt;
-                }
-            },
-            py::arg("gate"),
-            py::arg("successors"),
-            py::arg("forbidden_pins"),
-            py::arg("cache"),
-            R"(
-            Starting from the given gate, traverse the netlist and return only the next layer of sequential successor/predecessor gates.
-            Traverse over gates that are not sequential until a sequential gate is found.
-            Stop traversal at all sequential gates, but only adds those to the result that have not been reached through a pin of one of the forbidden types.
-            Provide a cache to speed up traversal when calling this function multiple times on the same netlist using the same forbidden pins.
-
-            :param hal_py.Gate gate: Start gate.
-            :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
-            :param set[hal_py.PinType] forbidden_pins: Sequential gates reached through these pins will not be part of the result.
-            :param dict[hal_py.Net, set[hal_py.Gate]] cache: A cache that can be used for better performance on repeated calls.
             :returns: The next sequential gates on success, ``None`` otherwise.
             :rtype: set[hal_py.Gate] or None
         )");
@@ -434,40 +368,6 @@ namespace hal
 
         py_netlist_traversal_decorator.def(
             "get_next_combinational_gates",
-            [](NetlistTraversalDecorator& self, const Net* net, bool successors, const std::set<PinType>& forbidden_pins, std::unordered_map<const Net*, std::set<Gate*>>* cache)
-                -> std::optional<std::set<Gate*>> {
-                auto res = self.get_next_combinational_gates(net, successors, forbidden_pins, cache);
-                if (res.is_ok())
-                {
-                    return res.get();
-                }
-                else
-                {
-                    log_error("python_context", "error encountered while getting next combinational gates:\n{}", res.get_error().get());
-                    return std::nullopt;
-                }
-            },
-            py::arg("net"),
-            py::arg("successors"),
-            py::arg("forbidden_pins"),
-            py::arg("cache"),
-            R"(
-            Starting from the given net, traverse the netlist and return all combinational successor/predecessor gates.
-            Continue traversal as long as further combinational gates are found and stop at gates that are not combinational.
-            All combinational gates found during traversal are added to the result.
-            Forbidden pins can be provided to, e.g., avoid the inclusion of logic in front of flip-flop control inputs.
-            Provide a cache to speed up traversal when calling this function multiple times on the same netlist using the same forbidden pins.
-
-            :param hal_py.Net net: Start net.
-            :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
-            :param set[hal_py.PinType] forbidden_pins: Netlist traversal stops at these pins.
-            :param dict[hal_py.Net, set[hal_py.Gate]] cache: A cache that can be used for better performance on repeated calls.
-            :returns: The next combinational gates on success, ``None`` otherwise.
-            :rtype: set[hal_py.Gate] or None
-        )");
-
-        py_netlist_traversal_decorator.def(
-            "get_next_combinational_gates",
             [](NetlistTraversalDecorator& self, const Gate* gate, bool successors, const std::set<PinType>& forbidden_pins) -> std::optional<std::set<Gate*>> {
                 auto res = self.get_next_combinational_gates(gate, successors, forbidden_pins, nullptr);
                 if (res.is_ok())
@@ -492,40 +392,6 @@ namespace hal
             :param hal_py.Gate gate: Start gate.
             :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
             :param set[hal_py.PinType] forbidden_pins: Netlist traversal stops at these pins.
-            :returns: The next combinational gates on success, ``None`` otherwise.
-            :rtype: set[hal_py.Gate] or None
-        )");
-
-        py_netlist_traversal_decorator.def(
-            "get_next_combinational_gates",
-            [](NetlistTraversalDecorator& self, const Gate* gate, bool successors, const std::set<PinType>& forbidden_pins, std::unordered_map<const Net*, std::set<Gate*>>* cache)
-                -> std::optional<std::set<Gate*>> {
-                auto res = self.get_next_combinational_gates(gate, successors, forbidden_pins, cache);
-                if (res.is_ok())
-                {
-                    return res.get();
-                }
-                else
-                {
-                    log_error("python_context", "error encountered while getting next combinational gates:\n{}", res.get_error().get());
-                    return std::nullopt;
-                }
-            },
-            py::arg("gate"),
-            py::arg("successors"),
-            py::arg("forbidden_pins"),
-            py::arg("cache"),
-            R"(
-            Starting from the given gate, traverse the netlist and return all combinational successor/predecessor gates.
-            Continue traversal as long as further combinational gates are found and stop at gates that are not combinational.
-            All combinational gates found during traversal are added to the result.
-            Forbidden pins can be provided to, e.g., avoid the inclusion of logic in front of flip-flop control inputs.
-            Provide a cache to speed up traversal when calling this function multiple times on the same netlist using the same forbidden pins.
-
-            :param hal_py.Gate gate: Start gate.
-            :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
-            :param set[hal_py.PinType] forbidden_pins: Netlist traversal stops at these pins.
-            :param dict[hal_py.Net, set[hal_py.Gate]] cache: A cache that can be used for better performance on repeated calls.
             :returns: The next combinational gates on success, ``None`` otherwise.
             :rtype: set[hal_py.Gate] or None
         )");

--- a/src/python_bindings/bindings/netlist_traversal_decorator.cpp
+++ b/src/python_bindings/bindings/netlist_traversal_decorator.cpp
@@ -169,5 +169,59 @@ namespace hal
             :returns: The next gates fulfilling the target gate filter condition on success, ``None`` otherwise.
             :rtype: set[hal_py.Gate] or None
         )");
+
+        py_netlist_traversal_decorator.def(
+            "get_next_sequential_gates",
+            [](NetlistTraversalDecorator& self, const Net* net, bool successors, const std::set<PinType>& forbidden_input_pins = {}, std::unordered_map<const Net*, std::set<Gate*>>* cache = nullptr)
+                -> std::optional<std::set<Gate*>> {
+                auto res = self.get_next_sequential_gates(net, successors, forbidden_input_pins, cache);
+                if (res.is_ok())
+                {
+                    return res.get();
+                }
+                else
+                {
+                    log_error("python_context", "error encountered while getting next sequential gates:\n{}", res.get_error().get());
+                    return std::nullopt;
+                }
+            },
+            py::arg("net"),
+            py::arg("successors"),
+            py::arg("forbidden_input_pins") = std::set<PinType>(),
+            py::arg("cache")                = nullptr,
+            R"(
+
+            :param hal_py.Net net: Start net.
+            :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
+
+            :rtype: set[hal_py.Gate] or None
+        )");
+
+        py_netlist_traversal_decorator.def(
+            "get_next_sequential_gates",
+            [](NetlistTraversalDecorator& self, const Gate* gate, bool successors, const std::set<PinType>& forbidden_input_pins = {}, std::unordered_map<const Net*, std::set<Gate*>>* cache = nullptr)
+                -> std::optional<std::set<Gate*>> {
+                auto res = self.get_next_sequential_gates(gate, successors, forbidden_input_pins, cache);
+                if (res.is_ok())
+                {
+                    return res.get();
+                }
+                else
+                {
+                    log_error("python_context", "error encountered while getting next sequential gates:\n{}", res.get_error().get());
+                    return std::nullopt;
+                }
+            },
+            py::arg("gate"),
+            py::arg("successors"),
+            py::arg("forbidden_input_pins") = std::set<PinType>(),
+            py::arg("cache")                = nullptr,
+            R"(
+
+            :param hal_py.Gate gate: Start gate.
+            :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
+
+            :rtype: set[hal_py.Gate] or None
+        )");
     }
 }    // namespace hal

--- a/src/python_bindings/bindings/netlist_traversal_decorator.cpp
+++ b/src/python_bindings/bindings/netlist_traversal_decorator.cpp
@@ -173,7 +173,7 @@ namespace hal
 
         py_netlist_traversal_decorator.def(
             "get_next_sequential_gates",
-            [](NetlistTraversalDecorator& self, const Net* net, bool successors, const std::set<PinType>& forbidden_pins = {}) -> std::optional<std::set<Gate*>> {
+            [](NetlistTraversalDecorator& self, const Net* net, bool successors, const std::set<PinType>& forbidden_pins) -> std::optional<std::set<Gate*>> {
                 auto res = self.get_next_sequential_gates(net, successors, forbidden_pins, nullptr);
                 if (res.is_ok())
                 {
@@ -187,7 +187,7 @@ namespace hal
             },
             py::arg("net"),
             py::arg("successors"),
-            py::arg("forbidden_pins") = std::set<PinType>(),
+            py::arg("forbidden_pins"),
             R"(
             Starting from the given net, traverse the netlist and return only the next layer of sequential successor/predecessor gates.
             Traverse over gates that are not sequential until a sequential gate is found.
@@ -235,7 +235,7 @@ namespace hal
 
         py_netlist_traversal_decorator.def(
             "get_next_sequential_gates",
-            [](NetlistTraversalDecorator& self, const Gate* gate, bool successors, const std::set<PinType>& forbidden_pins = {}) -> std::optional<std::set<Gate*>> {
+            [](NetlistTraversalDecorator& self, const Gate* gate, bool successors, const std::set<PinType>& forbidden_pins) -> std::optional<std::set<Gate*>> {
                 auto res = self.get_next_sequential_gates(gate, successors, forbidden_pins, nullptr);
                 if (res.is_ok())
                 {
@@ -249,7 +249,7 @@ namespace hal
             },
             py::arg("gate"),
             py::arg("successors"),
-            py::arg("forbidden_pins") = std::set<PinType>(),
+            py::arg("forbidden_pins"),
             R"(
             Starting from the given gate, traverse the netlist and return only the next layer of sequential successor/predecessor gates.
             Traverse over gates that are not sequential until a sequential gate is found.

--- a/src/python_bindings/bindings/netlist_traversal_decorator.cpp
+++ b/src/python_bindings/bindings/netlist_traversal_decorator.cpp
@@ -391,5 +391,119 @@ namespace hal
             :returns: A dict from each sequential gate to all its sequential successors on success, ``None`` otherwise.
             :rtype: dict[hal_py.Gate,set[hal_py.Gate]] or None
         )");
+
+        py_netlist_traversal_decorator.def(
+            "get_next_combinational_gates",
+            [](NetlistTraversalDecorator& self, const Net* net, bool successors) -> std::optional<std::set<Gate*>> {
+                auto res = self.get_next_combinational_gates(net, successors, nullptr);
+                if (res.is_ok())
+                {
+                    return res.get();
+                }
+                else
+                {
+                    log_error("python_context", "error encountered while getting next combinational gates:\n{}", res.get_error().get());
+                    return std::nullopt;
+                }
+            },
+            py::arg("net"),
+            py::arg("successors"),
+            R"(
+            Starting from the given net, traverse the netlist and return all combinational successor/predecessor gates.
+            Continue traversal as long as further combinational gates are found and stop at gates that are not combinational.
+            All combinational gates found during traversal are added to the result.
+
+            :param hal_py.Net net: Start net.
+            :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
+            :returns: The next combinational gates on success, ``None`` otherwise.
+            :rtype: set[hal_py.Gate] or None
+        )");
+
+        py_netlist_traversal_decorator.def(
+            "get_next_combinational_gates",
+            [](NetlistTraversalDecorator& self, const Net* net, bool successors, std::unordered_map<const Net*, std::set<Gate*>>* cache) -> std::optional<std::set<Gate*>> {
+                auto res = self.get_next_combinational_gates(net, successors, cache);
+                if (res.is_ok())
+                {
+                    return res.get();
+                }
+                else
+                {
+                    log_error("python_context", "error encountered while getting next combinational gates:\n{}", res.get_error().get());
+                    return std::nullopt;
+                }
+            },
+            py::arg("net"),
+            py::arg("successors"),
+            py::arg("cache"),
+            R"(
+            Starting from the given net, traverse the netlist and return all combinational successor/predecessor gates.
+            Continue traversal as long as further combinational gates are found and stop at gates that are not combinational.
+            All combinational gates found during traversal are added to the result.
+            Provide a cache to speed up traversal when calling this function multiple times on the same netlist.
+
+            :param hal_py.Net net: Start net.
+            :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
+            :param dict[hal_py.Net, set[hal_py.Gate]] cache: A cache that can be used for better performance on repeated calls.
+            :returns: The next combinational gates on success, ``None`` otherwise.
+            :rtype: set[hal_py.Gate] or None
+        )");
+
+        py_netlist_traversal_decorator.def(
+            "get_next_combinational_gates",
+            [](NetlistTraversalDecorator& self, const Gate* gate, bool successors) -> std::optional<std::set<Gate*>> {
+                auto res = self.get_next_combinational_gates(gate, successors, nullptr);
+                if (res.is_ok())
+                {
+                    return res.get();
+                }
+                else
+                {
+                    log_error("python_context", "error encountered while getting next combinational gates:\n{}", res.get_error().get());
+                    return std::nullopt;
+                }
+            },
+            py::arg("gate"),
+            py::arg("successors"),
+            R"(
+            Starting from the given gate, traverse the netlist and return all combinational successor/predecessor gates.
+            Continue traversal as long as further combinational gates are found and stop at gates that are not combinational.
+            All combinational gates found during traversal are added to the result.
+
+            :param hal_py.Gate gate: Start gate.
+            :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
+            :returns: The next combinational gates on success, ``None`` otherwise.
+            :rtype: set[hal_py.Gate] or None
+        )");
+
+        py_netlist_traversal_decorator.def(
+            "get_next_combinational_gates",
+            [](NetlistTraversalDecorator& self, const Gate* gate, bool successors, std::unordered_map<const Net*, std::set<Gate*>>* cache) -> std::optional<std::set<Gate*>> {
+                auto res = self.get_next_combinational_gates(gate, successors, cache);
+                if (res.is_ok())
+                {
+                    return res.get();
+                }
+                else
+                {
+                    log_error("python_context", "error encountered while getting next combinational gates:\n{}", res.get_error().get());
+                    return std::nullopt;
+                }
+            },
+            py::arg("gate"),
+            py::arg("successors"),
+            py::arg("cache"),
+            R"(
+            Starting from the given gate, traverse the netlist and return all combinational successor/predecessor gates.
+            Continue traversal as long as further combinational gates are found and stop at gates that are not combinational.
+            All combinational gates found during traversal are added to the result.
+            Provide a cache to speed up traversal when calling this function multiple times on the same netlist.
+
+            :param hal_py.Gate gate: Start gate.
+            :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
+            :param dict[hal_py.Net, set[hal_py.Gate]] cache: A cache that can be used for better performance on repeated calls.
+            :returns: The next combinational gates on success, ``None`` otherwise.
+            :rtype: set[hal_py.Gate] or None
+        )");
     }
 }    // namespace hal

--- a/src/python_bindings/bindings/netlist_traversal_decorator.cpp
+++ b/src/python_bindings/bindings/netlist_traversal_decorator.cpp
@@ -337,7 +337,7 @@ namespace hal
 
             :param hal_py.Gate gate: Start gate.
             :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
-            :param set[hal_py.PinType] forbidden_pins: Sequential gates reached through these pins will not be part of the result. Defaults to an empty set.
+            :param set[hal_py.PinType] forbidden_pins: Sequential gates reached through these pins will not be part of the result.
             :returns: The next sequential gates on success, ``None`` otherwise.
             :rtype: set[hal_py.Gate] or None
         )");
@@ -404,8 +404,8 @@ namespace hal
 
         py_netlist_traversal_decorator.def(
             "get_next_combinational_gates",
-            [](NetlistTraversalDecorator& self, const Net* net, bool successors) -> std::optional<std::set<Gate*>> {
-                auto res = self.get_next_combinational_gates(net, successors, nullptr);
+            [](NetlistTraversalDecorator& self, const Net* net, bool successors, const std::set<PinType>& forbidden_pins) -> std::optional<std::set<Gate*>> {
+                auto res = self.get_next_combinational_gates(net, successors, forbidden_pins, nullptr);
                 if (res.is_ok())
                 {
                     return res.get();
@@ -418,21 +418,25 @@ namespace hal
             },
             py::arg("net"),
             py::arg("successors"),
+            py::arg("forbidden_pins"),
             R"(
             Starting from the given net, traverse the netlist and return all combinational successor/predecessor gates.
             Continue traversal as long as further combinational gates are found and stop at gates that are not combinational.
             All combinational gates found during traversal are added to the result.
+            Forbidden pins can be provided to, e.g., avoid the inclusion of logic in front of flip-flop control inputs.
 
             :param hal_py.Net net: Start net.
             :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
+            :param set[hal_py.PinType] forbidden_pins: Netlist traversal stops at these pins.
             :returns: The next combinational gates on success, ``None`` otherwise.
             :rtype: set[hal_py.Gate] or None
         )");
 
         py_netlist_traversal_decorator.def(
             "get_next_combinational_gates",
-            [](NetlistTraversalDecorator& self, const Net* net, bool successors, std::unordered_map<const Net*, std::set<Gate*>>* cache) -> std::optional<std::set<Gate*>> {
-                auto res = self.get_next_combinational_gates(net, successors, cache);
+            [](NetlistTraversalDecorator& self, const Net* net, bool successors, const std::set<PinType>& forbidden_pins, std::unordered_map<const Net*, std::set<Gate*>>* cache)
+                -> std::optional<std::set<Gate*>> {
+                auto res = self.get_next_combinational_gates(net, successors, forbidden_pins, cache);
                 if (res.is_ok())
                 {
                     return res.get();
@@ -445,15 +449,18 @@ namespace hal
             },
             py::arg("net"),
             py::arg("successors"),
+            py::arg("forbidden_pins"),
             py::arg("cache"),
             R"(
             Starting from the given net, traverse the netlist and return all combinational successor/predecessor gates.
             Continue traversal as long as further combinational gates are found and stop at gates that are not combinational.
             All combinational gates found during traversal are added to the result.
-            Provide a cache to speed up traversal when calling this function multiple times on the same netlist.
+            Forbidden pins can be provided to, e.g., avoid the inclusion of logic in front of flip-flop control inputs.
+            Provide a cache to speed up traversal when calling this function multiple times on the same netlist using the same forbidden pins.
 
             :param hal_py.Net net: Start net.
             :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
+            :param set[hal_py.PinType] forbidden_pins: Netlist traversal stops at these pins.
             :param dict[hal_py.Net, set[hal_py.Gate]] cache: A cache that can be used for better performance on repeated calls.
             :returns: The next combinational gates on success, ``None`` otherwise.
             :rtype: set[hal_py.Gate] or None
@@ -461,8 +468,8 @@ namespace hal
 
         py_netlist_traversal_decorator.def(
             "get_next_combinational_gates",
-            [](NetlistTraversalDecorator& self, const Gate* gate, bool successors) -> std::optional<std::set<Gate*>> {
-                auto res = self.get_next_combinational_gates(gate, successors, nullptr);
+            [](NetlistTraversalDecorator& self, const Gate* gate, bool successors, const std::set<PinType>& forbidden_pins) -> std::optional<std::set<Gate*>> {
+                auto res = self.get_next_combinational_gates(gate, successors, forbidden_pins, nullptr);
                 if (res.is_ok())
                 {
                     return res.get();
@@ -475,21 +482,25 @@ namespace hal
             },
             py::arg("gate"),
             py::arg("successors"),
+            py::arg("forbidden_pins"),
             R"(
             Starting from the given gate, traverse the netlist and return all combinational successor/predecessor gates.
             Continue traversal as long as further combinational gates are found and stop at gates that are not combinational.
             All combinational gates found during traversal are added to the result.
+            Forbidden pins can be provided to, e.g., avoid the inclusion of logic in front of flip-flop control inputs.
 
             :param hal_py.Gate gate: Start gate.
             :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
+            :param set[hal_py.PinType] forbidden_pins: Netlist traversal stops at these pins.
             :returns: The next combinational gates on success, ``None`` otherwise.
             :rtype: set[hal_py.Gate] or None
         )");
 
         py_netlist_traversal_decorator.def(
             "get_next_combinational_gates",
-            [](NetlistTraversalDecorator& self, const Gate* gate, bool successors, std::unordered_map<const Net*, std::set<Gate*>>* cache) -> std::optional<std::set<Gate*>> {
-                auto res = self.get_next_combinational_gates(gate, successors, cache);
+            [](NetlistTraversalDecorator& self, const Gate* gate, bool successors, const std::set<PinType>& forbidden_pins, std::unordered_map<const Net*, std::set<Gate*>>* cache)
+                -> std::optional<std::set<Gate*>> {
+                auto res = self.get_next_combinational_gates(gate, successors, forbidden_pins, cache);
                 if (res.is_ok())
                 {
                     return res.get();
@@ -502,15 +513,18 @@ namespace hal
             },
             py::arg("gate"),
             py::arg("successors"),
+            py::arg("forbidden_pins"),
             py::arg("cache"),
             R"(
             Starting from the given gate, traverse the netlist and return all combinational successor/predecessor gates.
             Continue traversal as long as further combinational gates are found and stop at gates that are not combinational.
             All combinational gates found during traversal are added to the result.
-            Provide a cache to speed up traversal when calling this function multiple times on the same netlist.
+            Forbidden pins can be provided to, e.g., avoid the inclusion of logic in front of flip-flop control inputs.
+            Provide a cache to speed up traversal when calling this function multiple times on the same netlist using the same forbidden pins.
 
             :param hal_py.Gate gate: Start gate.
             :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
+            :param set[hal_py.PinType] forbidden_pins: Netlist traversal stops at these pins.
             :param dict[hal_py.Net, set[hal_py.Gate]] cache: A cache that can be used for better performance on repeated calls.
             :returns: The next combinational gates on success, ``None`` otherwise.
             :rtype: set[hal_py.Gate] or None

--- a/src/python_bindings/bindings/netlist_traversal_decorator.cpp
+++ b/src/python_bindings/bindings/netlist_traversal_decorator.cpp
@@ -19,9 +19,10 @@ namespace hal
                const Net* net,
                bool successors,
                const std::function<bool(const Gate*)>& target_gate_filter,
+               bool continue_on_match                                                                     = false,
                const std::function<bool(const Endpoint*, const u32 current_depth)>& exit_endpoint_filter  = nullptr,
                const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr) -> std::optional<std::set<Gate*>> {
-                auto res = self.get_next_matching_gates(net, successors, target_gate_filter, exit_endpoint_filter, entry_endpoint_filter);
+                auto res = self.get_next_matching_gates(net, successors, target_gate_filter, continue_on_match, exit_endpoint_filter, entry_endpoint_filter);
                 if (res.is_ok())
                 {
                     return res.get();
@@ -35,17 +36,19 @@ namespace hal
             py::arg("net"),
             py::arg("successors"),
             py::arg("target_gate_filter"),
+            py::arg("continue_on_match")     = false,
             py::arg("exit_endpoint_filter")  = nullptr,
             py::arg("entry_endpoint_filter") = nullptr,
             R"(
             Starting from the given net, traverse the netlist and return only the successor/predecessor gates for which the ``target_gate_filter`` evaluates to ``True``.
             Traverse over gates that do not meet the ``target_gate_filter`` condition.
-            Stop traversal if (1) the ``target_gate_filter`` evaluates to ``True``, (2) the ``exit_endpoint_filter`` evaluates to ``False`` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal), or (3) the ``entry_endpoint_filter`` evaluates to ``False`` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
+            Stop traversal if (1) ``continue_on_match`` is ``False`` the ``target_gate_filter`` evaluates to ``True``, (2) the ``exit_endpoint_filter`` evaluates to ``False`` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal), or (3) the ``entry_endpoint_filter`` evaluates to ``False`` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
             Both the ``entry_endpoint_filter`` and the ``exit_endpoint_filter`` may be omitted.
 
             :param hal_py.Net net: Start net.
             :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
             :param lambda target_gate_filter: Filter condition that must be met for the target gates.
+            :param bool continue_on_match: Set ``True`` to continue even if ``target_gate_filter`` evaluated to ``True``, ``False`` otherwise. Defaults to ``False``.
             :param lambda exit_endpoint_filter: Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
             :param lambda entry_endpoint_filter: Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
             :returns: The next gates fulfilling the target gate filter condition on success, ``None`` otherwise.
@@ -58,9 +61,10 @@ namespace hal
                const Gate* gate,
                bool successors,
                const std::function<bool(const Gate*)>& target_gate_filter,
+               bool continue_on_match                                                                     = false,
                const std::function<bool(const Endpoint*, const u32 current_depth)>& exit_endpoint_filter  = nullptr,
                const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr) -> std::optional<std::set<Gate*>> {
-                auto res = self.get_next_matching_gates(gate, successors, target_gate_filter, exit_endpoint_filter, entry_endpoint_filter);
+                auto res = self.get_next_matching_gates(gate, successors, target_gate_filter, continue_on_match, exit_endpoint_filter, entry_endpoint_filter);
                 if (res.is_ok())
                 {
                     return res.get();
@@ -74,17 +78,19 @@ namespace hal
             py::arg("gate"),
             py::arg("successors"),
             py::arg("target_gate_filter"),
+            py::arg("continue_on_match")     = false,
             py::arg("exit_endpoint_filter")  = nullptr,
             py::arg("entry_endpoint_filter") = nullptr,
             R"(
             Starting from the given gate, traverse the netlist and return only the successor/predecessor gates for which the ``target_gate_filter`` evaluates to ``True``.
             Traverse over gates that do not meet the ``target_gate_filter`` condition.
-            Stop traversal if (1) the ``target_gate_filter`` evaluates to ``True``, (2) the ``exit_endpoint_filter`` evaluates to ``False`` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal), or (3) the ``entry_endpoint_filter`` evaluates to ``False`` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
+            Stop traversal if (1) ``continue_on_match`` is ``False`` the ``target_gate_filter`` evaluates to ``True``, (2) the ``exit_endpoint_filter`` evaluates to ``False`` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal), or (3) the ``entry_endpoint_filter`` evaluates to ``False`` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
             Both the ``entry_endpoint_filter`` and the ``exit_endpoint_filter`` may be omitted.
 
             :param hal_py.Gate gate: Start gate.
             :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
             :param lambda target_gate_filter: Filter condition that must be met for the target gates.
+            :param bool continue_on_match: Set ``True`` to continue even if ``target_gate_filter`` evaluated to ``True``, ``False`` otherwise. Defaults to ``False``.
             :param lambda exit_endpoint_filter: Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
             :param lambda entry_endpoint_filter: Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
             :returns: The next gates fulfilling the target gate filter condition on success, ``None`` otherwise.
@@ -96,10 +102,11 @@ namespace hal
             [](NetlistTraversalDecorator& self,
                const Net* net,
                bool successors,
-               const std::function<bool(const Gate*)>& target_gate_filter                                 = nullptr,
+               const std::function<bool(const Gate*)>& target_gate_filter,
+               bool continue_on_mismatch                                                                  = false,
                const std::function<bool(const Endpoint*, const u32 current_depth)>& exit_endpoint_filter  = nullptr,
                const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr) -> std::optional<std::set<Gate*>> {
-                auto res = self.get_next_matching_gates_until(net, successors, target_gate_filter, exit_endpoint_filter, entry_endpoint_filter);
+                auto res = self.get_next_matching_gates_until(net, successors, target_gate_filter, continue_on_mismatch, exit_endpoint_filter, entry_endpoint_filter);
                 if (res.is_ok())
                 {
                     return res.get();
@@ -112,19 +119,20 @@ namespace hal
             },
             py::arg("net"),
             py::arg("successors"),
-            py::arg("target_gate_filter")    = nullptr,
+            py::arg("target_gate_filter"),
+            py::arg("continue_on_mismatch")  = false,
             py::arg("exit_endpoint_filter")  = nullptr,
             py::arg("entry_endpoint_filter") = nullptr,
             R"(
             Starting from the given net, traverse the netlist and return only the successor/predecessor gates for which the ``target_gate_filter`` evaluates to ``True``.
             Continue traversal independent of whatever ``target_gate_filter`` evaluates to.
-            Stop traversal if (1) the ``exit_endpoint_filter`` evaluates to ``False`` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal) or (2) the ``entry_endpoint_filter`` evaluates to ``False`` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
-            The target_gate_filter may be omitted in which case all traversed gates will be returned.
-            Both ``entry_endpoint_filter`` and the ``exit_endpoint_filter`` may be omitted as well.
+            Stop traversal if (1) ``continue_on_mismatch`` is ``False`` the ``target_gate_filter`` evaluates to ``False``, (2) the ``exit_endpoint_filter`` evaluates to ``False`` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal), or (3) the ``entry_endpoint_filter`` evaluates to ``False`` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
+            Both ``entry_endpoint_filter`` and the ``exit_endpoint_filter`` may be omitted.
 
             :param hal_py.Net net: Start net.
             :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
             :param lambda target_gate_filter: Filter condition that must be met for the target gates.
+            :param bool continue_on_mismatch: Set ``True`` to continue even if ``target_gate_filter`` evaluated to ``False``, ``False`` otherwise. Defaults to ``False``.
             :param lambda exit_endpoint_filter: Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
             :param lambda entry_endpoint_filter: Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
             :returns: The next gates fulfilling the target gate filter condition on success, ``None`` otherwise.
@@ -136,10 +144,11 @@ namespace hal
             [](NetlistTraversalDecorator& self,
                const Gate* gate,
                bool successors,
-               const std::function<bool(const Gate*)>& target_gate_filter                                 = nullptr,
+               const std::function<bool(const Gate*)>& target_gate_filter,
+               bool continue_on_mismatch                                                                  = false,
                const std::function<bool(const Endpoint*, const u32 current_depth)>& exit_endpoint_filter  = nullptr,
                const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr) -> std::optional<std::set<Gate*>> {
-                auto res = self.get_next_matching_gates_until(gate, successors, target_gate_filter, exit_endpoint_filter, entry_endpoint_filter);
+                auto res = self.get_next_matching_gates_until(gate, successors, target_gate_filter, continue_on_mismatch, exit_endpoint_filter, entry_endpoint_filter);
                 if (res.is_ok())
                 {
                     return res.get();
@@ -152,19 +161,20 @@ namespace hal
             },
             py::arg("gate"),
             py::arg("successors"),
-            py::arg("target_gate_filter")    = nullptr,
+            py::arg("target_gate_filter"),
+            py::arg("continue_on_mismatch")  = false,
             py::arg("exit_endpoint_filter")  = nullptr,
             py::arg("entry_endpoint_filter") = nullptr,
             R"(
             Starting from the given gate, traverse the netlist and return only the successor/predecessor gates for which the ``target_gate_filter`` evaluates to ``True``.
             Continue traversal independent of whatever ``target_gate_filter`` evaluates to.
-            Stop traversal if (1) the ``exit_endpoint_filter`` evaluates to ``False`` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal) or (2) the ``entry_endpoint_filter`` evaluates to ``False`` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
-            The target_gate_filter may be omitted in which case all traversed gates will be returned.
-            Both ``entry_endpoint_filter`` and the ``exit_endpoint_filter`` may be omitted as well.
+            Stop traversal if (1) ``continue_on_mismatch`` is ``False`` the ``target_gate_filter`` evaluates to ``False``, (2) the ``exit_endpoint_filter`` evaluates to ``False`` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal), or (3) the ``entry_endpoint_filter`` evaluates to ``False`` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
+            Both ``entry_endpoint_filter`` and the ``exit_endpoint_filter`` may be omitted.
 
             :param hal_py.Gate gate: Start gate.
             :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
             :param lambda target_gate_filter: Filter condition that must be met for the target gates.
+            :param bool continue_on_mismatch: Set ``True`` to continue even if ``target_gate_filter`` evaluated to ``False``, ``False`` otherwise. Defaults to ``False``.
             :param lambda exit_endpoint_filter: Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
             :param lambda entry_endpoint_filter: Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
             :returns: The next gates fulfilling the target gate filter condition on success, ``None`` otherwise.
@@ -173,9 +183,9 @@ namespace hal
 
         py_netlist_traversal_decorator.def(
             "get_next_matching_gates_until_depth",
-            [](NetlistTraversalDecorator& self, const Net* net, bool successors, const std::function<bool(const Gate*)>& target_gate_filter = nullptr, u32 depth = 0)
+            [](NetlistTraversalDecorator& self, const Net* net, bool successors, u32 max_depth, const std::function<bool(const Gate*)>& target_gate_filter = nullptr)
                 -> std::optional<std::set<Gate*>> {
-                auto res = self.get_next_matching_gates_until_depth(net, successors, target_gate_filter, depth);
+                auto res = self.get_next_matching_gates_until_depth(net, successors, max_depth, target_gate_filter);
                 if (res.is_ok())
                 {
                     return res.get();
@@ -188,29 +198,29 @@ namespace hal
             },
             py::arg("net"),
             py::arg("successors"),
+            py::arg("max_depth"),
             py::arg("target_gate_filter") = nullptr,
-            py::arg("depth")              = 0,
             R"(
             Starting from the given net, traverse the netlist and return only the successor/predecessor gates for which the ``target_gate_filter`` evaluates to ``True``.
             Continue traversal independent of whatever ``target_gate_filter`` evaluates to.
             Stop traversal if the specified depth is reached.
             The current depth is counted starting at 1 for the destinations of the provided net. 
-            If no depth is provided, all gates between the start net and the global netlist outputs will be traversed.
+            For a ``max_depth`` of ``0``, all gates between the start net and the global netlist outputs will be traversed.
             The target_gate_filter may be omitted in which case all traversed gates will be returned.
 
             :param hal_py.Net net: Start net.
             :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
+            :param int max_depth: The maximum depth for netlist traversal starting from the start net.
             :param lambda target_gate_filter: Filter condition that must be met for the target gates.
-            :param int depth: The maximum depth for netlist traversal starting from the start net.
             :returns: The next gates fulfilling the target gate filter condition on success, ``None`` otherwise.
             :rtype: set[hal_py.Gate] or None
         )");
 
         py_netlist_traversal_decorator.def(
             "get_next_matching_gates_until_depth",
-            [](NetlistTraversalDecorator& self, const Gate* gate, bool successors, const std::function<bool(const Gate*)>& target_gate_filter = nullptr, u32 depth = 0)
+            [](NetlistTraversalDecorator& self, const Gate* gate, bool successors, u32 max_depth, const std::function<bool(const Gate*)>& target_gate_filter = nullptr)
                 -> std::optional<std::set<Gate*>> {
-                auto res = self.get_next_matching_gates_until_depth(gate, successors, target_gate_filter, depth);
+                auto res = self.get_next_matching_gates_until_depth(gate, successors, max_depth, target_gate_filter);
                 if (res.is_ok())
                 {
                     return res.get();
@@ -223,20 +233,20 @@ namespace hal
             },
             py::arg("gate"),
             py::arg("successors"),
+            py::arg("max_depth"),
             py::arg("target_gate_filter") = nullptr,
-            py::arg("depth")              = 0,
             R"(
             Starting from the given gate, traverse the netlist and return only the successor/predecessor gates for which the ``target_gate_filter`` evaluates to ``True``.
             Continue traversal independent of whatever ``target_gate_filter`` evaluates to.
             Stop traversal if the specified depth is reached.
             The current depth is counted starting at 1 for the direct successors/predecessors of the provided gate. 
-            If no depth is provided, all gates between the start gate and the global netlist outputs will be traversed.
+            For a ``max_depth`` of ``0``, all gates between the start gate and the global netlist outputs will be traversed.
             The target_gate_filter may be omitted in which case all traversed gates will be returned.
 
             :param hal_py.Gate gate: Start gate.
             :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
+            :param int max_depth: The maximum depth for netlist traversal starting from the start gate.
             :param lambda target_gate_filter: Filter condition that must be met for the target gates.
-            :param int depth: The maximum depth for netlist traversal starting from the start gate.
             :returns: The next gates fulfilling the target gate filter condition on success, ``None`` otherwise.
             :rtype: set[hal_py.Gate] or None
         )");

--- a/src/python_bindings/bindings/netlist_traversal_decorator.cpp
+++ b/src/python_bindings/bindings/netlist_traversal_decorator.cpp
@@ -112,7 +112,7 @@ namespace hal
             },
             py::arg("net"),
             py::arg("successors"),
-            py::arg("target_gate_filter"),
+            py::arg("target_gate_filter")    = nullptr,
             py::arg("exit_endpoint_filter")  = nullptr,
             py::arg("entry_endpoint_filter") = nullptr,
             R"(
@@ -152,7 +152,7 @@ namespace hal
             },
             py::arg("gate"),
             py::arg("successors"),
-            py::arg("target_gate_filter"),
+            py::arg("target_gate_filter")    = nullptr,
             py::arg("exit_endpoint_filter")  = nullptr,
             py::arg("entry_endpoint_filter") = nullptr,
             R"(
@@ -167,6 +167,76 @@ namespace hal
             :param lambda target_gate_filter: Filter condition that must be met for the target gates.
             :param lambda exit_endpoint_filter: Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
             :param lambda entry_endpoint_filter: Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
+            :returns: The next gates fulfilling the target gate filter condition on success, ``None`` otherwise.
+            :rtype: set[hal_py.Gate] or None
+        )");
+
+        py_netlist_traversal_decorator.def(
+            "get_next_matching_gates_until_depth",
+            [](NetlistTraversalDecorator& self, const Net* net, bool successors, const std::function<bool(const Gate*)>& target_gate_filter = nullptr, u32 depth = 0)
+                -> std::optional<std::set<Gate*>> {
+                auto res = self.get_next_matching_gates_until_depth(net, successors, target_gate_filter, depth);
+                if (res.is_ok())
+                {
+                    return res.get();
+                }
+                else
+                {
+                    log_error("python_context", "error encountered while getting next gates:\n{}", res.get_error().get());
+                    return std::nullopt;
+                }
+            },
+            py::arg("net"),
+            py::arg("successors"),
+            py::arg("target_gate_filter") = nullptr,
+            py::arg("depth")              = 0,
+            R"(
+            Starting from the given net, traverse the netlist and return only the successor/predecessor gates for which the ``target_gate_filter`` evaluates to ``True``.
+            Continue traversal independent of whatever ``target_gate_filter`` evaluates to.
+            Stop traversal if the specified depth is reached.
+            The current depth is counted starting at 1 for the destinations of the provided net. 
+            If no depth is provided, all gates between the start net and the global netlist outputs will be traversed.
+            The target_gate_filter may be omitted in which case all traversed gates will be returned.
+
+            :param hal_py.Net net: Start net.
+            :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
+            :param lambda target_gate_filter: Filter condition that must be met for the target gates.
+            :param int depth: The maximum depth for netlist traversal starting from the start net.
+            :returns: The next gates fulfilling the target gate filter condition on success, ``None`` otherwise.
+            :rtype: set[hal_py.Gate] or None
+        )");
+
+        py_netlist_traversal_decorator.def(
+            "get_next_matching_gates_until_depth",
+            [](NetlistTraversalDecorator& self, const Gate* gate, bool successors, const std::function<bool(const Gate*)>& target_gate_filter = nullptr, u32 depth = 0)
+                -> std::optional<std::set<Gate*>> {
+                auto res = self.get_next_matching_gates_until_depth(gate, successors, target_gate_filter, depth);
+                if (res.is_ok())
+                {
+                    return res.get();
+                }
+                else
+                {
+                    log_error("python_context", "error encountered while getting next gates:\n{}", res.get_error().get());
+                    return std::nullopt;
+                }
+            },
+            py::arg("gate"),
+            py::arg("successors"),
+            py::arg("target_gate_filter") = nullptr,
+            py::arg("depth")              = 0,
+            R"(
+            Starting from the given gate, traverse the netlist and return only the successor/predecessor gates for which the ``target_gate_filter`` evaluates to ``True``.
+            Continue traversal independent of whatever ``target_gate_filter`` evaluates to.
+            Stop traversal if the specified depth is reached.
+            The current depth is counted starting at 1 for the direct successors/predecessors of the provided gate. 
+            If no depth is provided, all gates between the start gate and the global netlist outputs will be traversed.
+            The target_gate_filter may be omitted in which case all traversed gates will be returned.
+
+            :param hal_py.Gate gate: Start gate.
+            :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
+            :param lambda target_gate_filter: Filter condition that must be met for the target gates.
+            :param int depth: The maximum depth for netlist traversal starting from the start gate.
             :returns: The next gates fulfilling the target gate filter condition on success, ``None`` otherwise.
             :rtype: set[hal_py.Gate] or None
         )");

--- a/src/python_bindings/bindings/netlist_traversal_decorator.cpp
+++ b/src/python_bindings/bindings/netlist_traversal_decorator.cpp
@@ -1,0 +1,173 @@
+#include "hal_core/python_bindings/python_bindings.h"
+
+namespace hal
+{
+    void netlist_traversal_decorator_init(py::module& m)
+    {
+        py::class_<NetlistTraversalDecorator> py_netlist_traversal_decorator(
+            m, "NetlistTraversalDecorator", R"(A netlist decorator that provides functionality to traverse the associated netlist without making any modifications.)");
+
+        py_netlist_traversal_decorator.def(py::init<Netlist&>(), py::arg("netlist"), R"(
+            Construct new NetlistTraversalDecorator object.
+
+            :param hal_py.Netlist netlist: The netlist to operate on.
+        )");
+
+        py_netlist_traversal_decorator.def(
+            "get_next_matching_gates",
+            [](NetlistTraversalDecorator& self,
+               const Net* net,
+               bool successors,
+               const std::function<bool(const Gate*)>& target_gate_filter,
+               const std::function<bool(const Endpoint*, const u32 current_depth)>& exit_endpoint_filter  = nullptr,
+               const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr) -> std::optional<std::set<Gate*>> {
+                auto res = self.get_next_matching_gates(net, successors, target_gate_filter, exit_endpoint_filter, entry_endpoint_filter);
+                if (res.is_ok())
+                {
+                    return res.get();
+                }
+                else
+                {
+                    log_error("python_context", "error encountered while getting next gates:\n{}", res.get_error().get());
+                    return std::nullopt;
+                }
+            },
+            py::arg("net"),
+            py::arg("successors"),
+            py::arg("target_gate_filter"),
+            py::arg("exit_endpoint_filter")  = nullptr,
+            py::arg("entry_endpoint_filter") = nullptr,
+            R"(
+            Starting from the given net, traverse the netlist and return only the successor/predecessor gates for which the ``target_gate_filter`` evaluates to ``True``.
+            Traverse over gates that do not meet the ``target_gate_filter`` condition.
+            Stop traversal if (1) the ``target_gate_filter`` evaluates to ``True``, (2) the ``exit_endpoint_filter`` evaluates to ``False`` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal), or (3) the ``entry_endpoint_filter`` evaluates to ``False`` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
+            Both the ``entry_endpoint_filter`` and the ``exit_endpoint_filter`` may be omitted.
+
+            :param hal_py.Net net: Start net.
+            :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
+            :param lambda target_gate_filter: Filter condition that must be met for the target gates.
+            :param lambda exit_endpoint_filter: Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
+            :param lambda entry_endpoint_filter: Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
+            :returns: The next gates fulfilling the target gate filter condition on success, ``None`` otherwise.
+            :rtype: set[hal_py.Gate] or None
+        )");
+
+        py_netlist_traversal_decorator.def(
+            "get_next_matching_gates",
+            [](NetlistTraversalDecorator& self,
+               const Gate* gate,
+               bool successors,
+               const std::function<bool(const Gate*)>& target_gate_filter,
+               const std::function<bool(const Endpoint*, const u32 current_depth)>& exit_endpoint_filter  = nullptr,
+               const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr) -> std::optional<std::set<Gate*>> {
+                auto res = self.get_next_matching_gates(gate, successors, target_gate_filter, exit_endpoint_filter, entry_endpoint_filter);
+                if (res.is_ok())
+                {
+                    return res.get();
+                }
+                else
+                {
+                    log_error("python_context", "error encountered while getting next gates:\n{}", res.get_error().get());
+                    return std::nullopt;
+                }
+            },
+            py::arg("gate"),
+            py::arg("successors"),
+            py::arg("target_gate_filter"),
+            py::arg("exit_endpoint_filter")  = nullptr,
+            py::arg("entry_endpoint_filter") = nullptr,
+            R"(
+            Starting from the given gate, traverse the netlist and return only the successor/predecessor gates for which the ``target_gate_filter`` evaluates to ``True``.
+            Traverse over gates that do not meet the ``target_gate_filter`` condition.
+            Stop traversal if (1) the ``target_gate_filter`` evaluates to ``True``, (2) the ``exit_endpoint_filter`` evaluates to ``False`` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal), or (3) the ``entry_endpoint_filter`` evaluates to ``False`` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
+            Both the ``entry_endpoint_filter`` and the ``exit_endpoint_filter`` may be omitted.
+
+            :param hal_py.Gate gate: Start gate.
+            :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
+            :param lambda target_gate_filter: Filter condition that must be met for the target gates.
+            :param lambda exit_endpoint_filter: Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
+            :param lambda entry_endpoint_filter: Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
+            :returns: The next gates fulfilling the target gate filter condition on success, ``None`` otherwise.
+            :rtype: set[hal_py.Gate] or None
+        )");
+
+        py_netlist_traversal_decorator.def(
+            "get_next_matching_gates_until",
+            [](NetlistTraversalDecorator& self,
+               const Net* net,
+               bool successors,
+               const std::function<bool(const Gate*)>& target_gate_filter                                 = nullptr,
+               const std::function<bool(const Endpoint*, const u32 current_depth)>& exit_endpoint_filter  = nullptr,
+               const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr) -> std::optional<std::set<Gate*>> {
+                auto res = self.get_next_matching_gates_until(net, successors, target_gate_filter, exit_endpoint_filter, entry_endpoint_filter);
+                if (res.is_ok())
+                {
+                    return res.get();
+                }
+                else
+                {
+                    log_error("python_context", "error encountered while getting next gates:\n{}", res.get_error().get());
+                    return std::nullopt;
+                }
+            },
+            py::arg("net"),
+            py::arg("successors"),
+            py::arg("target_gate_filter"),
+            py::arg("exit_endpoint_filter")  = nullptr,
+            py::arg("entry_endpoint_filter") = nullptr,
+            R"(
+            Starting from the given net, traverse the netlist and return only the successor/predecessor gates for which the ``target_gate_filter`` evaluates to ``True``.
+            Continues traversal independent of whatever ``target_gate_filter`` evaluates to.
+            Stop traversal if (1) the ``exit_endpoint_filter`` evaluates to ``False`` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal) or (2) the ``entry_endpoint_filter`` evaluates to ``False`` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
+            The target_gate_filter may be omitted in which case all traversed gates will be returned.
+            Both ``entry_endpoint_filter`` and the ``exit_endpoint_filter`` may be omitted as well.
+
+            :param hal_py.Net net: Start net.
+            :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
+            :param lambda target_gate_filter: Filter condition that must be met for the target gates.
+            :param lambda exit_endpoint_filter: Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
+            :param lambda entry_endpoint_filter: Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
+            :returns: The next gates fulfilling the target gate filter condition on success, ``None`` otherwise.
+            :rtype: set[hal_py.Gate] or None
+        )");
+
+        py_netlist_traversal_decorator.def(
+            "get_next_matching_gates_until",
+            [](NetlistTraversalDecorator& self,
+               const Gate* gate,
+               bool successors,
+               const std::function<bool(const Gate*)>& target_gate_filter                                 = nullptr,
+               const std::function<bool(const Endpoint*, const u32 current_depth)>& exit_endpoint_filter  = nullptr,
+               const std::function<bool(const Endpoint*, const u32 current_depth)>& entry_endpoint_filter = nullptr) -> std::optional<std::set<Gate*>> {
+                auto res = self.get_next_matching_gates_until(gate, successors, target_gate_filter, exit_endpoint_filter, entry_endpoint_filter);
+                if (res.is_ok())
+                {
+                    return res.get();
+                }
+                else
+                {
+                    log_error("python_context", "error encountered while getting next gates:\n{}", res.get_error().get());
+                    return std::nullopt;
+                }
+            },
+            py::arg("gate"),
+            py::arg("successors"),
+            py::arg("target_gate_filter"),
+            py::arg("exit_endpoint_filter")  = nullptr,
+            py::arg("entry_endpoint_filter") = nullptr,
+            R"(
+            Starting from the given gate, traverse the netlist and return only the successor/predecessor gates for which the ``target_gate_filter`` evaluates to ``True``.
+            Stop traversal if (1) the ``exit_endpoint_filter`` evaluates to ``False`` on a fan-in/out endpoint (i.e., when exiting the current gate during traversal) or (2) the ``entry_endpoint_filter`` evaluates to ``False`` on a successor/predecessor endpoint (i.e., when entering the next gate during traversal).
+            The target_gate_filter may be omitted in which case all traversed gates will be returned.
+            Both ``entry_endpoint_filter`` and the ``exit_endpoint_filter`` may be omitted as well.
+
+            :param hal_py.Gate gate: Start gate.
+            :param bool successors: Set ``True`` to get successors, set ``False`` to get predecessors.
+            :param lambda target_gate_filter: Filter condition that must be met for the target gates.
+            :param lambda exit_endpoint_filter: Filter condition that determines whether to stop traversal on a fan-in/out endpoint.
+            :param lambda entry_endpoint_filter: Filter condition that determines whether to stop traversal on a successor/predecessor endpoint.
+            :returns: The next gates fulfilling the target gate filter condition on success, ``None`` otherwise.
+            :rtype: set[hal_py.Gate] or None
+        )");
+    }
+}    // namespace hal

--- a/src/python_bindings/python_bindings.cpp
+++ b/src/python_bindings/python_bindings.cpp
@@ -75,6 +75,8 @@ namespace hal
 
         netlist_modification_decorator_init(m);
 
+        netlist_traversal_decorator_init(m);
+
         log_init(m);
 
 #ifndef PYBIND11_MODULE

--- a/tests/netlist/decorators.cpp
+++ b/tests/netlist/decorators.cpp
@@ -672,6 +672,15 @@ namespace hal {
                     EXPECT_TRUE(res.is_ok());
                     EXPECT_EQ(res.get(), std::set<Gate*>({dff4, dff5, dff6}));
                 }
+                {
+                    std::unordered_map<const Net*, std::set<Gate*>> cache;
+                    const auto res1 = trav_dec.get_next_matching_gates(dff2, true, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::ff); }, false, nullptr, nullptr, &cache);
+                    EXPECT_TRUE(res1.is_ok());
+                    EXPECT_EQ(res1.get(), std::set<Gate*>({dff5, dff6, dff7, dff3}));
+                    const auto res2 = trav_dec.get_next_matching_gates(dff3, true, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::ff); }, false, nullptr, nullptr, &cache);
+                    EXPECT_TRUE(res2.is_ok());
+                    EXPECT_EQ(res2.get(), std::set<Gate*>({dff6, dff7, dff3}));
+                }
 
                 // predecessors
                 {
@@ -683,6 +692,15 @@ namespace hal {
                     const auto res = trav_dec.get_next_matching_gates(dff5, false, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::ff); }, false, [](const Endpoint* ep, u32 current_depth) { return ep->get_pin()->get_type() == PinType::data || ep->get_pin()->get_type() == PinType::none; }, nullptr);
                     EXPECT_TRUE(res.is_ok());
                     EXPECT_EQ(res.get(), std::set<Gate*>({dff0, dff1, dff2}));
+                }
+                {
+                    std::unordered_map<const Net*, std::set<Gate*>> cache;
+                    const auto res1 = trav_dec.get_next_matching_gates(dff6, false, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::ff); }, false, nullptr, nullptr, &cache);
+                    EXPECT_TRUE(res1.is_ok());
+                    EXPECT_EQ(res1.get(), std::set<Gate*>({dff1, dff2, dff3, sff0, sff1}));
+                    const auto res2 = trav_dec.get_next_matching_gates(dff7, false, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::ff); }, false, nullptr, nullptr, &cache);
+                    EXPECT_TRUE(res2.is_ok());
+                    EXPECT_EQ(res2.get(), std::set<Gate*>({dff2, dff3, sff0, sff1}));
                 }
             }
             {

--- a/tests/netlist/decorators.cpp
+++ b/tests/netlist/decorators.cpp
@@ -689,7 +689,39 @@ namespace hal {
                 // test NetlistModificationDecorator::get_next_matching_gates_until
                 const auto trav_dec = NetlistTraversalDecorator(*(nl.get()));
 
-                // TODO implement
+                // successors
+                {
+                    const auto res = trav_dec.get_next_matching_gates_until(dff1, true, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::combinational); }, false, nullptr, nullptr);
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({and0, or2, or0, or3, and1, or4}));
+                }
+                {
+                    const auto res = trav_dec.get_next_matching_gates_until(dff1, true, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::combinational); }, true, nullptr, [](const Endpoint* ep, u32 current_depth) { return !ep->get_gate()->get_type()->has_property(GateTypeProperty::ff); });
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({and0, or2, or0, or3, and1, or4}));
+                }
+
+                // predecessors
+                {
+                    const auto res = trav_dec.get_next_matching_gates_until(dff5, false, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::combinational); }, false, nullptr, nullptr);
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({or3, and0, and1, inv6}));
+                }
+                {
+                    const auto res = trav_dec.get_next_matching_gates_until(dff4, false, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::combinational); }, false, nullptr, nullptr);
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({or2, inv0, and0, inv6}));
+                }
+                {
+                    const auto res = trav_dec.get_next_matching_gates_until(dff5, false, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::combinational); }, true, nullptr, [](const Endpoint* ep, u32 current_depth) { return !ep->get_gate()->get_type()->has_property(GateTypeProperty::ff); });
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({or3, and0, and1, inv6}));
+                }
+                {
+                    const auto res = trav_dec.get_next_matching_gates_until(dff5, false, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::combinational); }, true, [](const Endpoint* ep, u32 current_depth) { return ep->get_pin()->get_type() == PinType::data || ep->get_pin()->get_type() == PinType::none; }, [](const Endpoint* ep, u32 current_depth) { return !ep->get_gate()->get_type()->has_property(GateTypeProperty::ff); });
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({or3, and0, and1}));
+                }
             }
             {
                 // test NetlistModificationDecorator::get_next_matching_gates_until_depth

--- a/tests/netlist/decorators.cpp
+++ b/tests/netlist/decorators.cpp
@@ -695,7 +695,63 @@ namespace hal {
                 // test NetlistModificationDecorator::get_next_matching_gates_until_depth
                 const auto trav_dec = NetlistTraversalDecorator(*(nl.get()));
 
-                // TODO implement
+                // successors
+                {
+                    const auto res = trav_dec.get_next_matching_gates_until_depth(dff1, true, 2, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::ff); });
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({}));
+                }
+                {
+                    const auto res = trav_dec.get_next_matching_gates_until_depth(dff1, true, 3, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::ff); });
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({dff4, dff5, dff6}));
+                }
+                {
+                    const auto res = trav_dec.get_next_matching_gates_until_depth(dff1, true, 4, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::ff); });
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({dff0, dff4, dff5, dff6}));
+                }
+                {
+                    const auto res = trav_dec.get_next_matching_gates_until_depth(dff1, true, 5, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::ff); });
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({dff0, dff4, dff5, dff6, dff8, dff9, dff10}));
+                }
+                {
+                    const auto res = trav_dec.get_next_matching_gates_until_depth(dff1, true, 6, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::ff); });
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({dff0, dff4, dff5, dff6, dff8, dff9, dff10}));
+                }
+                {
+                    const auto res = trav_dec.get_next_matching_gates_until_depth(dff1, true, 100, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::ff); });
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({dff0, dff4, dff5, dff6, dff8, dff9, dff10}));
+                }
+                // predecessors
+                {
+                    const auto res = trav_dec.get_next_matching_gates_until_depth(dff5, false, 2, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::ff); });
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({sff0, sff1}));
+                }
+                {
+                    const auto res = trav_dec.get_next_matching_gates_until_depth(dff5, false, 3, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::ff); });
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({dff0, dff1, dff2, sff0, sff1}));
+                }
+                {
+                    const auto res = trav_dec.get_next_matching_gates_until_depth(dff5, false, 4, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::ff); });
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({dff0, dff1, dff2, sff0, sff1}));
+                }
+                {
+                    const auto res = trav_dec.get_next_matching_gates_until_depth(dff5, false, 5, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::ff); });
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({dff0, dff1, dff2, sff0, sff1}));
+                }
+                {
+                    const auto res = trav_dec.get_next_matching_gates_until_depth(dff5, false, 100, [](const Gate* g) { return g->get_type()->has_property(GateTypeProperty::ff); });
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({dff0, dff1, dff2, sff0, sff1}));
+                }
             }
             {
                 // test NetlistModificationDecorator::get_next_sequential_gates

--- a/tests/netlist/decorators.cpp
+++ b/tests/netlist/decorators.cpp
@@ -7,6 +7,7 @@
 #include "hal_core/netlist/decorators/boolean_function_net_decorator.h"
 #include "hal_core/netlist/decorators/boolean_function_decorator.h"
 #include "hal_core/netlist/decorators/netlist_modification_decorator.h"
+#include "hal_core/netlist/decorators/netlist_traversal_decorator.h"
 #include "netlist_test_utils.h"
 
 
@@ -503,6 +504,280 @@ namespace hal {
             EXPECT_EQ(m_net45->get_num_of_destinations(), 0);
             EXPECT_TRUE(m_net45->is_a_source(a1, "O"));
             EXPECT_TRUE(m_net45->is_a_source(a3, "O"));
+        }
+        TEST_END
+    }
+
+    /**
+     * Test NetlistTraversalDecorator.
+     */
+    TEST_F(DecoratorTest, check_netlist_traversal_decorator)
+    {
+        TEST_START
+        {
+            // setup test netlist
+            auto nl = test_utils::create_empty_netlist();
+            ASSERT_NE(nl, nullptr);
+
+            auto* nl_raw = nl.get();
+
+            auto gl = nl_raw->get_gate_library();
+            ASSERT_NE(gl, nullptr);
+
+            auto dff0 = nl_raw->create_gate(gl->get_gate_type_by_name("DFFRE"), "DFF0");
+            auto dff1 = nl_raw->create_gate(gl->get_gate_type_by_name("DFFRE"), "DFF1");
+            auto dff2 = nl_raw->create_gate(gl->get_gate_type_by_name("DFFRE"), "DFF2");
+            auto dff3 = nl_raw->create_gate(gl->get_gate_type_by_name("DFFRE"), "DFF3");
+            auto dff4 = nl_raw->create_gate(gl->get_gate_type_by_name("DFFRE"), "DFF4");
+            auto dff5 = nl_raw->create_gate(gl->get_gate_type_by_name("DFFRE"), "DFF5");
+            auto dff6 = nl_raw->create_gate(gl->get_gate_type_by_name("DFFRE"), "DFF6");
+            auto dff7 = nl_raw->create_gate(gl->get_gate_type_by_name("DFFRE"), "DFF7");
+            auto dff8 = nl_raw->create_gate(gl->get_gate_type_by_name("DFFRE"), "DFF8");
+            auto dff9 = nl_raw->create_gate(gl->get_gate_type_by_name("DFFRE"), "DFF9");
+            auto dff10 = nl_raw->create_gate(gl->get_gate_type_by_name("DFFRE"), "DFF10");
+            auto dff11 = nl_raw->create_gate(gl->get_gate_type_by_name("DFFRE"), "DFF11");
+
+            auto sff0 = nl_raw->create_gate(gl->get_gate_type_by_name("DFF"), "SFF0");
+            auto sff1 = nl_raw->create_gate(gl->get_gate_type_by_name("DFF"), "SFF1");
+
+            auto or0 = nl_raw->create_gate(gl->get_gate_type_by_name("OR2"), "OR0");
+            auto or1 = nl_raw->create_gate(gl->get_gate_type_by_name("OR2"), "OR1");
+            auto or2 = nl_raw->create_gate(gl->get_gate_type_by_name("OR2"), "OR2");
+            auto or3 = nl_raw->create_gate(gl->get_gate_type_by_name("OR2"), "OR3");
+            auto or4 = nl_raw->create_gate(gl->get_gate_type_by_name("OR2"), "OR4");
+            auto or5 = nl_raw->create_gate(gl->get_gate_type_by_name("OR2"), "OR5");
+
+            auto inv0 = nl_raw->create_gate(gl->get_gate_type_by_name("INV"), "INV0");
+            auto inv1 = nl_raw->create_gate(gl->get_gate_type_by_name("INV"), "INV1");
+            auto inv2 = nl_raw->create_gate(gl->get_gate_type_by_name("INV"), "INV2");
+            auto inv3 = nl_raw->create_gate(gl->get_gate_type_by_name("INV"), "INV3");
+            auto inv4 = nl_raw->create_gate(gl->get_gate_type_by_name("INV"), "INV4");
+            auto inv5 = nl_raw->create_gate(gl->get_gate_type_by_name("INV"), "INV5");
+
+            auto and0 = nl_raw->create_gate(gl->get_gate_type_by_name("AND2"), "AND0");
+            auto and1 = nl_raw->create_gate(gl->get_gate_type_by_name("AND2"), "AND1");
+            auto and2 = nl_raw->create_gate(gl->get_gate_type_by_name("AND2"), "AND2");
+
+            Net* clk = test_utils::connect_global_in(nl_raw, dff0, "CLK", "clk");
+            test_utils::connect_global_in(nl_raw, dff1, "CLK");
+            test_utils::connect_global_in(nl_raw, dff2, "CLK");
+            test_utils::connect_global_in(nl_raw, dff3, "CLK");
+            test_utils::connect_global_in(nl_raw, dff4, "CLK");
+            test_utils::connect_global_in(nl_raw, dff5, "CLK");
+            test_utils::connect_global_in(nl_raw, dff6, "CLK");
+            test_utils::connect_global_in(nl_raw, dff7, "CLK");
+            test_utils::connect_global_in(nl_raw, dff8, "CLK");
+            test_utils::connect_global_in(nl_raw, dff9, "CLK");
+            test_utils::connect_global_in(nl_raw, dff10, "CLK");
+            test_utils::connect_global_in(nl_raw, dff11, "CLK");
+            test_utils::connect_global_in(nl_raw, sff0, "CLK");
+            test_utils::connect_global_in(nl_raw, sff1, "CLK");
+
+            Net* net_0 = test_utils::connect(nl_raw, or2, "O", or0, "I0", "net_0");
+            Net* in_0 = test_utils::connect_global_in(nl_raw, or0, "I1", "in_0");
+            Net* net_1 = test_utils::connect(nl_raw, or0, "O", dff0, "D", "net_1");
+            Net* in_1 = test_utils::connect_global_in(nl_raw, dff1, "D", "in_1");
+            Net* in_2 = test_utils::connect_global_in(nl_raw, dff2, "D", "in_2");
+            Net* in_3 = test_utils::connect_global_in(nl_raw, or1, "I0", "in_3");
+            Net* net_2 = test_utils::connect(nl_raw, or5, "O", or1, "I1", "net_2");
+            Net* net_3 = test_utils::connect(nl_raw, or1, "O", dff3, "D", "net_3");
+
+            Net* net_4 = test_utils::connect(nl_raw, dff0, "Q", inv0, "I", "net_4");
+            Net* net_5 = test_utils::connect(nl_raw, dff0, "Q", and0, "I0", "net_5");
+            Net* net_6 = test_utils::connect(nl_raw, dff1, "Q", and0, "I1", "net_6");
+            Net* net_7 = test_utils::connect(nl_raw, dff1, "Q", and1, "I0", "net_7");
+            Net* net_8 = test_utils::connect(nl_raw, dff2, "Q", and1, "I1", "net_8");
+            Net* net_9 = test_utils::connect(nl_raw, dff2, "Q", and2, "I0", "net_9");
+            Net* net_10 = test_utils::connect(nl_raw, dff3, "Q", and2, "I1", "net_10");
+            Net* net_11 = test_utils::connect(nl_raw, dff3, "Q", inv1, "I", "net_11");
+
+            Net* net_12 = test_utils::connect(nl_raw, inv0, "O", or2, "I0", "net_12");
+            Net* net_13 = test_utils::connect(nl_raw, and0, "O", or2, "I1", "net_13");
+            Net* net_14 = test_utils::connect(nl_raw, and0, "O", or3, "I0", "net_14");
+            Net* net_15 = test_utils::connect(nl_raw, and1, "O", or3, "I1", "net_15");
+            Net* net_16 = test_utils::connect(nl_raw, and1, "O", or4, "I0", "net_16");
+            Net* net_17 = test_utils::connect(nl_raw, and2, "O", or4, "I1", "net_17");
+            Net* net_18 = test_utils::connect(nl_raw, and2, "O", or5, "I0", "net_18");
+            Net* net_19 = test_utils::connect(nl_raw, inv1, "O", or5, "I1", "net_19");
+
+            Net* net_20 = test_utils::connect(nl_raw, or2, "O", dff4, "D", "net_20");
+            Net* net_21 = test_utils::connect(nl_raw, or3, "O", dff5, "D", "net_21");
+            Net* net_22 = test_utils::connect(nl_raw, or4, "O", dff6, "D", "net_22");
+            Net* net_23 = test_utils::connect(nl_raw, or5, "O", dff7, "D", "net_23");
+
+            Net* net_24 = test_utils::connect(nl_raw, dff4, "Q", inv2, "I", "net_24");
+            Net* net_25 = test_utils::connect(nl_raw, dff5, "Q", inv3, "I", "net_25");
+            Net* net_26 = test_utils::connect(nl_raw, dff6, "Q", inv4, "I", "net_26");
+            Net* net_27 = test_utils::connect(nl_raw, dff7, "Q", inv5, "I", "net_27");
+
+            Net* net_28 = test_utils::connect(nl_raw, inv2, "O", dff8, "D", "net_28");
+            Net* net_29 = test_utils::connect(nl_raw, inv3, "O", dff9, "D", "net_29");
+            Net* net_30 = test_utils::connect(nl_raw, inv4, "O", dff10, "D", "net_30");
+            Net* net_31 = test_utils::connect(nl_raw, inv5, "O", dff11, "D", "net_31");
+
+            Net* out_0 = test_utils::connect_global_out(nl_raw, dff8, "Q", "out_0");
+            Net* out_1 = test_utils::connect_global_out(nl_raw, dff9, "Q", "out_1");
+            Net* out_2 = test_utils::connect_global_out(nl_raw, dff10, "Q", "out_2");
+            Net* out_3 = test_utils::connect_global_out(nl_raw, dff11, "Q", "out_3");
+
+            Net* in_4 = test_utils::connect_global_in(nl_raw, sff0, "D", "in_4");
+            Net* net_32 = test_utils::connect(nl_raw, sff0, "Q", sff1, "D", "net_32");
+
+            Net* en = test_utils::connect(nl_raw, sff0, "Q", dff0, "EN", "en");
+            test_utils::connect(nl_raw, sff0, "Q", dff1, "EN");
+            test_utils::connect(nl_raw, sff0, "Q", dff2, "EN");
+            test_utils::connect(nl_raw, sff0, "Q", dff3, "EN");
+            test_utils::connect(nl_raw, sff0, "Q", dff4, "EN");
+            test_utils::connect(nl_raw, sff0, "Q", dff5, "EN");
+            test_utils::connect(nl_raw, sff0, "Q", dff6, "EN");
+            test_utils::connect(nl_raw, sff0, "Q", dff7, "EN");
+            test_utils::connect(nl_raw, sff0, "Q", dff8, "EN");
+            test_utils::connect(nl_raw, sff0, "Q", dff9, "EN");
+            test_utils::connect(nl_raw, sff0, "Q", dff10, "EN");
+            test_utils::connect(nl_raw, sff0, "Q", dff11, "EN");
+
+            Net* rst = test_utils::connect(nl_raw, sff1, "Q", dff0, "R", "rst");
+            test_utils::connect(nl_raw, sff1, "Q", dff1, "R");
+            test_utils::connect(nl_raw, sff1, "Q", dff2, "R");
+            test_utils::connect(nl_raw, sff1, "Q", dff3, "R");
+            test_utils::connect(nl_raw, sff1, "Q", dff4, "R");
+            test_utils::connect(nl_raw, sff1, "Q", dff5, "R");
+            test_utils::connect(nl_raw, sff1, "Q", dff6, "R");
+            test_utils::connect(nl_raw, sff1, "Q", dff7, "R");
+            test_utils::connect(nl_raw, sff1, "Q", dff8, "R");
+            test_utils::connect(nl_raw, sff1, "Q", dff9, "R");
+            test_utils::connect(nl_raw, sff1, "Q", dff10, "R");
+            test_utils::connect(nl_raw, sff1, "Q", dff11, "R");
+
+
+            {
+                // test NetlistModificationDecorator::get_next_matching_gates
+                const auto trav_dec = NetlistTraversalDecorator(*(nl.get()));
+
+                // TODO implement
+            }
+            {
+                // test NetlistModificationDecorator::get_next_matching_gates_until
+                const auto trav_dec = NetlistTraversalDecorator(*(nl.get()));
+
+                // TODO implement
+            }
+            {
+                // test NetlistModificationDecorator::get_next_matching_gates_until_depth
+                const auto trav_dec = NetlistTraversalDecorator(*(nl.get()));
+
+                // TODO implement
+            }
+            {
+                // test NetlistModificationDecorator::get_next_sequential_gates
+                const auto trav_dec = NetlistTraversalDecorator(*(nl.get()));
+
+                // successors
+                {
+                    const auto res = trav_dec.get_next_sequential_gates(dff0, true, {}, nullptr);
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({dff0, dff4, dff5}));
+                }
+                {
+                    const auto res = trav_dec.get_next_sequential_gates(dff2, true, {}, nullptr);
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({dff5, dff6, dff7, dff3}));
+                }
+                {
+                    const auto res = trav_dec.get_next_sequential_gates(dff4, true, {}, nullptr);
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({dff8}));
+                }
+                {
+                    const auto res = trav_dec.get_next_sequential_gates(dff8, true, {}, nullptr);
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>());
+                }
+                {
+                    const auto res = trav_dec.get_next_sequential_gates(sff0, true, {}, nullptr);
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({sff1, dff0, dff1, dff2, dff3, dff4, dff5, dff6, dff7, dff8, dff9, dff10, dff11}));
+                }
+                {
+                    const auto res = trav_dec.get_next_sequential_gates(sff0, true, {PinType::enable, PinType::reset}, nullptr);
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({sff1}));
+                }
+                {
+                    const auto res = trav_dec.get_next_sequential_gates(sff1, true, {}, nullptr);
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({dff0, dff1, dff2, dff3, dff4, dff5, dff6, dff7, dff8, dff9, dff10, dff11}));
+                }
+                {
+                    const auto res = trav_dec.get_next_sequential_gates(sff1, true, {PinType::enable, PinType::reset}, nullptr);
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({}));
+                }
+                {
+                    std::unordered_map<const Net*, std::set<Gate*>> cache;
+                    const auto res1 = trav_dec.get_next_sequential_gates(dff1, true, {}, &cache);
+                    EXPECT_TRUE(res1.is_ok());
+                    EXPECT_EQ(res1.get(), std::set<Gate*>({dff4, dff5, dff6, dff0}));
+
+                    const auto res2 = trav_dec.get_next_sequential_gates(dff2, true, {}, &cache);
+                    EXPECT_TRUE(res2.is_ok());
+                    EXPECT_EQ(res2.get(), std::set<Gate*>({dff5, dff6, dff7, dff3}));
+                }
+
+                // predecessors
+                {
+                    const auto res = trav_dec.get_next_sequential_gates(dff4, false, {}, nullptr);
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({dff0, dff1, sff0, sff1}));
+                }
+                {
+                    const auto res = trav_dec.get_next_sequential_gates(dff4, false, {PinType::enable, PinType::reset, PinType::clock}, nullptr);
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({dff0, dff1}));
+                }
+                {
+                    const auto res = trav_dec.get_next_sequential_gates(dff5, false, {PinType::enable, PinType::reset, PinType::clock}, nullptr);
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({dff0, dff1, dff2}));
+                }
+                {
+                    const auto res = trav_dec.get_next_sequential_gates(dff0, false, {PinType::enable, PinType::reset, PinType::clock}, nullptr);
+                    EXPECT_TRUE(res.is_ok());
+                    EXPECT_EQ(res.get(), std::set<Gate*>({dff0, dff1}));
+                }
+                {
+                    std::unordered_map<const Net*, std::set<Gate*>> cache;
+                    const auto res1 = trav_dec.get_next_sequential_gates(dff5, false, {}, &cache);
+                    EXPECT_TRUE(res1.is_ok());
+                    EXPECT_EQ(res1.get(), std::set<Gate*>({dff0, dff1, dff2, sff0, sff1}));
+
+                    const auto res2 = trav_dec.get_next_sequential_gates(dff6, false, {}, &cache);
+                    EXPECT_TRUE(res2.is_ok());
+                    EXPECT_EQ(res2.get(), std::set<Gate*>({dff1, dff2, dff3, sff0, sff1}));
+                }
+                {
+                    std::unordered_map<const Net*, std::set<Gate*>> cache;
+                    const auto res1 = trav_dec.get_next_sequential_gates(dff5, false, {PinType::enable, PinType::reset, PinType::clock}, &cache);
+                    EXPECT_TRUE(res1.is_ok());
+                    EXPECT_EQ(res1.get(), std::set<Gate*>({dff0, dff1, dff2}));
+
+                    const auto res2 = trav_dec.get_next_sequential_gates(dff6, false, {PinType::enable, PinType::reset, PinType::clock}, &cache);
+                    EXPECT_TRUE(res2.is_ok());
+                    EXPECT_EQ(res2.get(), std::set<Gate*>({dff1, dff2, dff3}));
+                }
+            }
+            {
+                // test NetlistModificationDecorator::get_next_sequential_gates_map
+                const auto trav_dec = NetlistTraversalDecorator(*(nl.get()));
+
+                // TODO implement
+            }
+            {
+                // test NetlistModificationDecorator::get_next_combinational_gates
+                const auto trav_dec = NetlistTraversalDecorator(*(nl.get()));
+
+                // TODO implement
+            }
         }
         TEST_END
     }


### PR DESCRIPTION
* added NetlistTraversalDecorator to the HAL core to collect all functions traversing the netlist and returning some set of gates depending on the specified conditions in one place
* moved some functions from netlist_utils (old ones now deprecated)
* old functions still used, e.g., in the GUI, will need some cleanup in the future
* get_(shortest_)path and get_(complex_)gate_chain functions must still be moved