### PR TITLE
utils.h: add missing include

### DIFF
--- a/include/hal_core/utilities/utils.h
+++ b/include/hal_core/utilities/utils.h
@@ -32,6 +32,7 @@
 #include "hal_core/defines.h"
 #include "hal_core/utilities/result.h"
 
+#include <algorithm>
 #include <functional>
 #include <set>
 #include <sstream>


### PR DESCRIPTION
std::sort is defined in the algorithm header. Compilation with GCC 14 fails otherwise.