### PR TITLE
Fix building with bitwuzla>=0.4.0 due to breaking API changes

### DIFF
--- a/src/netlist/boolean_function/solver.cpp
+++ b/src/netlist/boolean_function/solver.cpp
@@ -237,12 +237,11 @@ namespace hal
 
                 // First, create a Bitwuzla options instance.
                 bitwuzla::Options options;
+                bitwuzla::TermManager tm;
                 // We will parse example file `smt2/quickstart.smt2`.
                 // Create parser instance.
                 // We expect no error to occur.
-                const char* smt2_char_string = input.c_str();
 
-                auto in_stream = fmemopen((void*)smt2_char_string, strlen(smt2_char_string), "r");
                 std::stringbuf result_string;
                 std::ostream output_stream(&result_string);
 
@@ -256,16 +255,16 @@ namespace hal
                 // std::filesystem::path tmp_path = utils::get_unique_temp_directory().get();
                 // std::string output_file        = std::string(tmp_path) + "/out.smt2";
 
-                bitwuzla::parser::Parser parser(options, "VIRTUAL_FILE", in_stream, "smt2", &output_stream);
+                bitwuzla::parser::Parser parser(tm, options, "smt2", &output_stream);
                 // Now parse the input file.
-                std::string err_msg = parser.parse(false);
-
-                if (!err_msg.empty())
+                try
                 {
-                    return ERR("failed to parse input file: " + err_msg);
+                    parser.parse(input, false, false);
                 }
-
-                fclose(in_stream);
+                catch (bitwuzla::Exception& e)
+                {
+                    return ERR("failed to parse input file: " + e.msg());
+                }
 
                 std::string output(result_string.str());
                 // std::cout << "output" << std::endl;


### PR DESCRIPTION
After installing Bitwuzla, HAL fails to build with:

```
/hal-emsec/src/netlist/boolean_function/solver.cpp: In function ‘hal::Result<std::tuple<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > hal::SMT::Bitwuzla::query_library(const std::string&, const hal::SMT::QueryConfig&)’:
/hal-emsec/src/netlist/boolean_function/solver.cpp:259:107: error: no matching function for call to ‘bitwuzla::parser::Parser::Parser(bitwuzla::Options&, const char [13], _IO_FILE*&, const char [5], std::ostream*)’
  259 |                 bitwuzla::parser::Parser parser(options, "VIRTUAL_FILE", in_stream, "smt2", &output_stream);
      |                                                                                                           ^
In file included from /hal-emsec/src/netlist/boolean_function/solver.cpp:12:
/usr/include/bitwuzla/cpp/parser.h:65:3: note: candidate: ‘bitwuzla::parser::Parser::Parser(bitwuzla::TermManager&, bitwuzla::Options&, const std::string&, std::ostream*)’
   65 |   Parser(TermManager &tm,
      |   ^~~~~~
/usr/include/bitwuzla/cpp/parser.h:65:3: note:   candidate expects 4 arguments, 5 provided
/hal-emsec/src/netlist/boolean_function/solver.cpp:261:51: error: no matching function for call to ‘bitwuzla::parser::Parser::parse(bool)’
  261 |                 std::string err_msg = parser.parse(false);
      |                                       ~~~~~~~~~~~~^~~~~~~
/usr/include/bitwuzla/cpp/parser.h:98:8: note: candidate: ‘void bitwuzla::parser::Parser::parse(const std::string&, bool, bool)’
   98 |   void parse(const std::string &input,
      |        ^~~~~
/usr/include/bitwuzla/cpp/parser.h:98:33: note:   no known conversion for argument 1 from ‘bool’ to ‘const std::string&’ {aka ‘const std::__cxx11::basic_string<char>&’}
   98 |   void parse(const std::string &input,
      |              ~~~~~~~~~~~~~~~~~~~^~~~~
/usr/include/bitwuzla/cpp/parser.h:114:8: note: candidate: ‘void bitwuzla::parser::Parser::parse(const std::string&, std::istream&, bool)’
  114 |   void parse(const std::string &infile_name,
      |        ^~~~~
/usr/include/bitwuzla/cpp/parser.h:114:8: note:   candidate expects 3 arguments, 1 provided
/hal-emsec/src/netlist/boolean_function/solver.cpp: In function ‘hal::Result<std::tuple<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > hal::SMT::Bitwuzla::query_binary(const std::string&, const hal::SMT::QueryConfig&)’:
/hal-emsec/src/netlist/boolean_function/solver.cpp:289:83: warning: unused parameter ‘input’ [-Wunused-parameter]
  289 |             Result<std::tuple<bool, std::string>> query_binary(const std::string& input, const QueryConfig& config)
      |                                                                ~~~~~~~~~~~~~~~~~~~^~~~~
ninja: build stopped: subcommand failed.
```

This is due to breaking API changes introduced by Bitwuzla version 0.4.0: https://github.com/bitwuzla/bitwuzla/blob/main/NEWS.md#news-for-version-040. Bitwuzla is currently at version 0.7.0.