### PR TITLE
Fix build: wrap logged enums with `fmt::underlying`

### DIFF
--- a/plugins/module_identification/src/api/module_identification.cpp
+++ b/plugins/module_identification/src/api/module_identification.cpp
@@ -406,7 +406,7 @@ namespace hal
 
                 const u32 num_threads = std::min(config.m_max_thread_count, std::thread::hardware_concurrency() - 1);
 
-                log_info("module_identification", "running with {} threads and {} multithreading priority", num_threads, config.m_multithreading_priority);
+                log_info("module_identification", "running with {} threads and {} multithreading priority", num_threads, fmt::underlying(config.m_multithreading_priority));
 
                 auto stats = Statistics();
 

--- a/plugins/z3_utils/src/simplification.cpp
+++ b/plugins/z3_utils/src/simplification.cpp
@@ -617,7 +617,7 @@ namespace hal
                     return false;
 
                 default: {
-                    log_error("z3_utils", "commutative check not implemeted for type {}!", t);
+                    log_error("z3_utils", "commutative check not implemeted for type {}!", fmt::underlying(t));
                     return false;
                 }
             }


### PR DESCRIPTION
With fmt v10+, build currently fails:

```
/usr/include/spdlog/logger.h:140:12:   required from ‘void spdlog::logger::info(fmt::v11::format_string<T ...>, Args&& ...) [with Args = {const unsigned int&, const hal::module_identification::MultithreadingPriority&}; fmt::v11::format_string<T ...> = fmt::v11::fstring<const unsigned int&, const hal::module_identification::MultithreadingPriority&>]’
  140 |         log(level::info, fmt, std::forward<Args>(args)...);
      |         ~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/hal-emsec/plugins/module_identification/src/api/module_identification.cpp:409:17:   required from here
   70 | #define log_info(channel, ...) LOG_CHANNEL(channel)->info(__VA_ARGS__)
      |                                                          ^
/usr/include/fmt/base.h:2235:45: error: ‘fmt::v11::detail::type_is_unformattable_for<hal::module_identification::MultithreadingPriority, char> _’ has incomplete type
 2235 |     type_is_unformattable_for<T, char_type> _;
      |                                    
```

It turns out it is now needed to wrap enums with `fmt::underlying`. See also https://stackoverflow.com/a/77751342/13649511.