### PR TITLE
Bugfix: add static cast for subgraph size return value

### DIFF
--- a/plugins/resynthesis/src/resynthesis.cpp
+++ b/plugins/resynthesis/src/resynthesis.cpp
@@ -1058,7 +1058,7 @@ namespace hal
             // delete the created directory and the contained files
             std::filesystem::remove_all(base_path);
 
-            return OK(subgraph.size());
+            return OK(static_cast<unsigned int>(subgraph.size()));
         }
 
         Result<u32> resynthesize_subgraph_of_type(Netlist* nl, const std::vector<const GateType*>& gate_types, GateLibrary* target_gl)


### PR DESCRIPTION
In the `resynthesize_subgraph` function, we have changed the return type of `subgraph.size()` to `static_cast<unsigned int>(subgraph.size())`. This is to ensure that the return value's type and bit width matches the declared type in the function signature.
The previous code might have caused compiler warnings (errors on darwin).