### PR TITLE
Fix: Loop counter overflow in SBoxDatabase::add

### DIFF
--- a/plugins/hawkeye/src/sbox_database.cpp
+++ b/plugins/hawkeye/src/sbox_database.cpp
@@ -304,7 +304,7 @@ namespace hal
                 return ERR("S-box '" + name + "' has bit-size greater 8, but only S-boxes of up to 8 bits are supported");
             }
 
-            for (u8 alpha = 0; alpha < sbox.size(); alpha++)
+            for (size_t alpha = 0; alpha < sbox.size(); alpha++)
             {
                 std::vector<u8> sbox_alpha;
                 for (u32 i = 0; i < sbox.size(); i++)


### PR DESCRIPTION
When creating your own S-box database, adding a S-box with more than 255 entries (e.g., the AES S-box with 256 entries) causes the loop counter to wrap around due to the use of an 8-bit unsigned integer (`u8`).
This leads to an infinite loop, since the counter resets to 0 after reaching 255 and the loop condition remains true.
This commit fixes the issue by replacing the `u8` counter with a properly sized type (`size_t`) to prevent integer overflow and ensure correct loop termination.