### PR TITLE
Feature: shortest path from gate to module

### DIFF
--- a/include/hal_core/netlist/netlist_utils.h
+++ b/include/hal_core/netlist/netlist_utils.h
@@ -337,7 +337,6 @@ namespace hal
                                                                    const std::function<bool(const Gate*)>& filter = nullptr);
 
         /**
-         * \deprecated
          * Find the shortest path (i.e., theresult set with the lowest number of gates) that connects the start gate with the end gate. 
          * The gate where the search started from will be the first in the result vector, the end gate will be the last. 
          * If there is no such path an empty vector is returned. If there is more than one path with the same length only the first one is returned.
@@ -347,9 +346,18 @@ namespace hal
          * @param[in] search_both_directions - True to additionally check whether a shorter path from end to start exists, false otherwise.
          * @return A vector of gates that connect the start with end gate (possibly in reverse order).
          */
-        [[deprecated("Will be removed in a future version, use NetlistTraversalDecorator::get_shortest_path instead.")]] CORE_API std::vector<Gate*>
-            get_shortest_path(Gate* start_gate, Gate* end_gate, bool search_both_directions = false);
+        CORE_API std::vector<Gate*> get_shortest_path(Gate* start_gate, Gate* end_gate, bool search_both_directions = false);
 
-        CORE_API std::vector<Gate*> get_shortest_path_to_module(Gate* start_gate, Module* end_module);
+        /**
+         * Find the shortest path (i.e., theresult set with the lowest number of gates) that connects the start gate with any gate from the given module.
+         * The gate where the search started from will be the first in the result vector, the end gate will be the last.
+         * If there is no such path an empty vector is returned. If there is more than one path with the same length only the first one is returned.
+         *
+         * @param[in] start_gate - The gate to start from.
+         * @param[in] end_gate - The gate to connect to.
+         * @param[in] search_both_directions - True to additionally check whether a shorter path from end to start exists, false otherwise.
+         * @return A vector of gates that connect the start with end gate (possibly in reverse order).
+         */
+        CORE_API std::vector<Gate*> get_shortest_path(Gate* start_gate, Module* end_module);
     }    // namespace netlist_utils
 }    // namespace hal

--- a/include/hal_core/netlist/netlist_utils.h
+++ b/include/hal_core/netlist/netlist_utils.h
@@ -349,5 +349,7 @@ namespace hal
          */
         [[deprecated("Will be removed in a future version, use NetlistTraversalDecorator::get_shortest_path instead.")]] CORE_API std::vector<Gate*>
             get_shortest_path(Gate* start_gate, Gate* end_gate, bool search_both_directions = false);
+
+        CORE_API std::vector<Gate*> get_shortest_path_to_module(Gate* start_gate, Module* end_module);
     }    // namespace netlist_utils
 }    // namespace hal

--- a/plugins/gui/include/gui/graph_widget/contexts/graph_context.h
+++ b/plugins/gui/include/gui/graph_widget/contexts/graph_context.h
@@ -126,6 +126,9 @@ namespace hal
          */
         bool isModuleUnfolded(const u32 moduleId) const;
 
+
+        void refreshModule(const u32 moduleId);
+
         /**
          * Unfold a specific module. The specified module is removed from the context and replaced by its Gate%s and
          * submodules.

--- a/plugins/gui/include/gui/graph_widget/contexts/graph_context.h
+++ b/plugins/gui/include/gui/graph_widget/contexts/graph_context.h
@@ -325,9 +325,10 @@ namespace hal
         }
 
         /**
-		 * Move node to antother grid location
-		 */
-        void moveNodeAction(const QPoint& from, const QPoint& to);
+         * Update placement of nodes already existing in view
+         * @param plc - the placement hash (Node -> QPoint)
+         */
+        void updatePlacement(const GridPlacement& plc);
 
         /**
          * Returns whether the scene is in an updating process (i.e. layouter process) or not.

--- a/plugins/gui/include/gui/graph_widget/graph_context_manager.h
+++ b/plugins/gui/include/gui/graph_widget/graph_context_manager.h
@@ -417,6 +417,8 @@ namespace hal
         static SettingsItemCheckbox* sSettingNetGroupingToPins;
 
         static SettingsItemCheckbox* sSettingPanOnMiddleButton;
+
+        static SettingsItemCheckbox* sSettingLayoutOnEveryChange;
     Q_SIGNALS:
         /**
          * Q_SIGNAL that notifies about the creation of a new context by the context manager.

--- a/plugins/gui/include/gui/graph_widget/graph_graphics_view.h
+++ b/plugins/gui/include/gui/graph_widget/graph_graphics_view.h
@@ -122,12 +122,12 @@ namespace hal
 
     public Q_SLOTS:
         /**
-         * highlight shortest path between two gates by putting the items on path into a new group
+         * highlight shortest path between source gate and target node by putting the items on path into a new group
          *
          * @param idFrom - id of gate where path starts
          * @param idTo - id of gate where path ends
          */
-        void handleShortestPath(u32 idFrom, u32 idTo);
+        void handleShortestPath(u32 idFrom, Node nodeTo);
 
         /**
          * remove selected nodes from view
@@ -146,7 +146,8 @@ namespace hal
         void handleUnfoldAllAction();
 
         void handleShortestPathToView();
-        void handleQueryShortestPath();
+        void handleQueryShortestPathGate();
+        void handleQueryShortestPathModule();
         void handleSelectOutputs();
         void handleSelectInputs();
 

--- a/plugins/gui/include/gui/graph_widget/graph_graphics_view.h
+++ b/plugins/gui/include/gui/graph_widget/graph_graphics_view.h
@@ -146,6 +146,7 @@ namespace hal
         void handleUnfoldAllAction();
 
         void handleShortestPathToView();
+        void handleShortestModulePathToView();
         void handleQueryShortestPathGate();
         void handleQueryShortestPathModule();
         void handleSelectOutputs();
@@ -183,6 +184,8 @@ namespace hal
         void resizeEvent(QResizeEvent* event) override;
 
     private:
+
+        enum SearchAction {PredecessorGate, SuccessorGate, SuccessorModule};
         void mousePressEventNotItemDrag(QMouseEvent* event);
         void showContextMenu(const QPoint& pos);
 

--- a/plugins/gui/include/gui/graph_widget/items/nets/standard_arrow_net.h
+++ b/plugins/gui/include/gui/graph_widget/items/nets/standard_arrow_net.h
@@ -35,7 +35,6 @@ namespace hal {
      * @brief A standard net that has parts of a separated net.
      *
      * The GraphicsNet that can be used to display nets in the scene.
-     * Currently only used in GraphLayouter::alternateLayout().
      */
     class StandardArrowNet : public StandardGraphicsNet
     {

--- a/plugins/gui/include/gui/graph_widget/items/nodes/gates/standard_graphics_gate.h
+++ b/plugins/gui/include/gui/graph_widget/items/nodes/gates/standard_graphics_gate.h
@@ -116,10 +116,8 @@ namespace hal
 
         static QPen sPen;
 
-        static QFont sTextFont[2];
         static QFont sPinFont;
 
-        static qreal sTextFontHeight[2];
 
         static qreal sColorBarHeight;
 
@@ -144,8 +142,6 @@ namespace hal
 
         void format(const bool& adjust_size_to_grid);
 
-        QPointF mTextPosition[2];
-
         QVector<float> mInputPinTextWidth;
         QVector<float> mOutputPinTextWidth;
         static const int sIconPadding;
@@ -155,7 +151,5 @@ namespace hal
         static const QPixmap& iconPixmap();
         static QColor legibleColor(const QColor& bgColor);
 
-    public:
-        static QColor sTextColor;
     };
 }

--- a/plugins/gui/include/gui/graph_widget/items/nodes/graphics_node.h
+++ b/plugins/gui/include/gui/graph_widget/items/nodes/graphics_node.h
@@ -28,6 +28,7 @@
 #include "gui/graph_widget/items/graphics_item.h"
 
 #include <QString>
+#include <QFont>
 
 namespace hal
 {
@@ -199,15 +200,47 @@ namespace hal
          */
         void set_name(const QString& name);
 
+        /**
+         * Loads the cosmetic setting that will be applied to all GraphicsModules.
+         */
+        static void loadSettings();
+
+        /**
+         * Pen color for text lines
+         */
+        static QColor sTextColor;
+
+
     //    qreal xOffset() const;
     //    qreal yOffset() const;
 
     protected:
         /**
+         * The text font for node name and type. Consider to change it to non-static in case derived class wants to overwrite
+         */
+        static QFont sTextFont[3];
+
+        /**
+         * Height of selected font
+         */
+        static qreal sTextFontHeight[3];
+
+
+        /**
          * The text in the center of the GraphicsNode. Each index stores one line of text. Therefore there is a maximum
          * of 3 lines in total.
          */
         QString mNodeText[3];
+
+        /**
+         * Text position in box.
+         */
+        QPointF mTextPosition[3];
+
+        /**
+         * Maximum text width, used to determine box width
+         */
+        qreal mMaxTextWidth;
 
         /**
          * The <b>width</b> of the GraphicsNode
@@ -232,5 +265,15 @@ namespace hal
          * netId=0 implies that no net is connected to the output pin at pinIdx.
          */
         QMultiHash<u32,int> mOutputByNet;
+
+        /**
+         * Set text lines, on init adjust width, else truncate lines
+         */
+        void setNodeText(const QString* lines, bool init);
+
+        /**
+         * Init text position after box width has been calculated
+         */
+        void initTextPosition(qreal y0, qreal spacing);
     };
 }

--- a/plugins/gui/include/gui/graph_widget/items/nodes/graphics_node.h
+++ b/plugins/gui/include/gui/graph_widget/items/nodes/graphics_node.h
@@ -63,9 +63,8 @@ namespace hal
          *
          * @param type - The type of the GraphicsItem (i.e. module, gate or net)
          * @param id - The id of the underlying object (e.g. the module id if ItemType::Module)
-         * @param name - The name of the node
          */
-        GraphicsNode(const ItemType type, const u32 id, const QString& name);
+        GraphicsNode(const ItemType type, const u32 id);
 
          /**
           * Get the bounding rectangle of the GrahpicsNode that represent its size. Therefore the returned rectangle is

--- a/plugins/gui/include/gui/graph_widget/items/nodes/modules/graphics_module.h
+++ b/plugins/gui/include/gui/graph_widget/items/nodes/modules/graphics_module.h
@@ -56,7 +56,7 @@ namespace hal
          *
          * @param m - The underlying module of this GraphicsModule
          */
-        void setModuleLabel(const Module* m);
+        void setModuleLabel(const Module* m, bool init=false);
 
     protected:
         /**

--- a/plugins/gui/include/gui/graph_widget/items/nodes/modules/graphics_module.h
+++ b/plugins/gui/include/gui/graph_widget/items/nodes/modules/graphics_module.h
@@ -51,6 +51,13 @@ namespace hal
          */
         explicit GraphicsModule(Module* m);
 
+        /**
+         * Set the text label for module box.
+         *
+         * @param m - The underlying module of this GraphicsModule
+         */
+        void setModuleLabel(const Module* m);
+
     protected:
         /**
          * Represents one pin (both input or output) of a module. It stores the pin type name and the id of the net

--- a/plugins/gui/include/gui/graph_widget/items/nodes/modules/standard_graphics_module.h
+++ b/plugins/gui/include/gui/graph_widget/items/nodes/modules/standard_graphics_module.h
@@ -117,10 +117,7 @@ namespace hal
 
         static QPen sPen;
 
-        static QFont sTextFont[3];
         static QFont sPinFont;
-
-        static qreal sTextFontHeight[3];
 
         static qreal sColorBarHeight;
 
@@ -142,15 +139,11 @@ namespace hal
 
         void format(const bool& adjust_size_to_grid);
 
-        QPointF mTextPosition[3];
-
         QVector<QPointF> mOutputPinPositions;
         static const int sIconPadding;
         static const QSize sIconSize;
 
         static QPixmap* sIconInstance;
         static const QPixmap& iconPixmap();
-    public:
-        static QColor sTextColor;
     };
 }    // namespace hal

--- a/plugins/gui/include/gui/graph_widget/layouters/graph_layouter.h
+++ b/plugins/gui/include/gui/graph_widget/layouters/graph_layouter.h
@@ -260,7 +260,6 @@ namespace hal
          * Does the actual layout process.
          */
         void layout();
-        void alternateLayout();
 
         /**
          * Gets the GraphicsScene the layouter works on.

--- a/plugins/gui/include/gui/graph_widget/layouters/graph_layouter.h
+++ b/plugins/gui/include/gui/graph_widget/layouters/graph_layouter.h
@@ -284,6 +284,8 @@ namespace hal
 
         void dumpNodePositions(const QPoint& search) const;
 
+        void updatePlacement(const GridPlacement& plc);
+
         void setNodePosition(const Node& n, const QPoint& p);
         void swapNodePositions(const Node& n1, const Node& n2);
         void removeNodeFromMaps(const Node& n);

--- a/plugins/gui/include/gui/gui_def.h
+++ b/plugins/gui/include/gui/gui_def.h
@@ -144,7 +144,13 @@ namespace hal
         GridPlacement(const QHash<hal::Node,QPoint>& data) : QHash<hal::Node,QPoint>(data) {;}
 
         void setGatePosition(u32 gateId, std::pair<int,int>p, bool swap = false) {
-            QPoint pos = QPoint(gatePosition(gateId)->first, gatePosition(gateId)->second); //position of current gate to move
+            std::pair<int,int>* posPtr = gatePosition(gateId);
+            if (!posPtr)
+            {
+                log_warning("gui", "Gate id {} cannot be moved, not found in current placement", gateId);
+                return;
+            }
+            QPoint pos = QPoint(posPtr->first, posPtr->second); //position of current gate to move
             hal::Node nd = key(QPoint(p.first, p.second)); //find the node in the destination
 
             if(!nd.isNull() && !swap) //if the destination placement is not available
@@ -159,8 +165,15 @@ namespace hal
             else
                 operator[](hal::Node(gateId,hal::Node::Gate)) = QPoint(p.first,p.second);
         }
+
         void setModulePosition(u32 moduleId, std::pair<int,int>p, bool swap = false){
-            QPoint pos = QPoint(modulePosition(moduleId)->first, modulePosition(moduleId)->second);
+            std::pair<int,int>* posPtr = modulePosition(moduleId);
+            if (!posPtr)
+            {
+                log_warning("gui", "Module id {} cannot be moved, not found in current placement", moduleId);
+                return;
+            }
+            QPoint pos = QPoint(posPtr->first, posPtr->second); //position of current module to move
             hal::Node nd = key(QPoint(p.first, p.second));
 
             if(!nd.isNull() && !swap)
@@ -174,11 +187,13 @@ namespace hal
             }
             else
                 operator[](hal::Node(moduleId,hal::Node::Module)) = QPoint(p.first,p.second);};
+
         std::pair<int,int>* gatePosition(u32 gateId) const
         {
             auto it = constFind(hal::Node(gateId,hal::Node::Gate));
             return (it == constEnd() ? nullptr : new std::pair<int,int>(it->x(),it->y()));
         }
+
         std::pair<int,int>* modulePosition(u32 moduleId) const
         {
             auto it = constFind(hal::Node(moduleId,hal::Node::Module));

--- a/plugins/gui/include/gui/module_model/module_model.h
+++ b/plugins/gui/include/gui/module_model/module_model.h
@@ -252,11 +252,18 @@ namespace hal
         void updateModuleParent(const Module* module);
 
         /**
-         * Updates the ModuleItems for the specified module. The specified module MUST be contained in the item model.
+         * Updates the ModuleItems name for the specified module. The specified module MUST be contained in the item model.
          *
          * @param id - The id of the module to update
          */
         void updateModuleName(const u32 id);
+
+        /**
+         * Updates the ModuleItems type for the specified module. The specified module MUST be contained in the item model.
+         *
+         * @param id - The id of the module to update
+         */
+        void updateModuleType(const u32 id);
 
         /**
          * Updates the ModuleItems for the specified gate. The specified gate MUST be contained in the item model.
@@ -283,6 +290,8 @@ namespace hal
 
     private Q_SLOTS:
         void handleModuleNameChanged(Module* mod);
+
+        void handleModuleTypeChanged(Module* mod);
 
         void handleModuleRemoved(Module* mod);
 

--- a/plugins/gui/src/graph_widget/contexts/graph_context.cpp
+++ b/plugins/gui/src/graph_widget/contexts/graph_context.cpp
@@ -7,6 +7,7 @@
 #include "gui/graph_widget/layout_locker.h"
 #include "gui/graph_widget/graphics_scene.h"
 #include "gui/graph_widget/graph_widget.h"
+#include "gui/graph_widget/items/nodes/modules/standard_graphics_module.h"
 #include "gui/context_manager_widget/context_manager_widget.h"
 #include "gui/gui_globals.h"
 #include "gui/gui_def.h"
@@ -479,6 +480,18 @@ namespace hal
 
         if(mUserUpdateCount == 0)
             update();
+    }
+
+    void GraphContext::refreshModule(const u32 moduleId)
+    {
+        NodeBox* box = getLayouter()->boxes().boxForNode(Node(moduleId,Node::Module));
+        if (!box) return;
+        Module* m = gNetlist->get_module_by_id(moduleId);
+        if (!m) return;
+        GraphicsModule* gm = dynamic_cast<GraphicsModule*>(box->item());
+        if (!gm) return;
+        gm->setModuleLabel(m);
+        gm->update();
     }
 
     Node GraphContext::nodeForGate(const u32 id) const

--- a/plugins/gui/src/graph_widget/contexts/graph_context.cpp
+++ b/plugins/gui/src/graph_widget/contexts/graph_context.cpp
@@ -533,12 +533,9 @@ namespace hal
         if (mParentWidget) mParentWidget->storeViewport();
     }
 
-    void GraphContext::moveNodeAction(const QPoint& from, const QPoint& to)
+    void GraphContext::updatePlacement(const GridPlacement& plc)
     {
-        const QMap<QPoint,Node> nodeMap = mLayouter->positionToNodeMap();
-        auto it = nodeMap.find(from);
-        if (it==nodeMap.constEnd()) return;
-        mLayouter->setNodePosition(it.value(),to);
+        mLayouter->updatePlacement(plc);
         scheduleSceneUpdate();
     }
 

--- a/plugins/gui/src/graph_widget/graph_graphics_view.cpp
+++ b/plugins/gui/src/graph_widget/graph_graphics_view.cpp
@@ -547,8 +547,11 @@ namespace hal
                     recursionLevelMenu(preSucMenu->addMenu("Add common successors to view …"),true, &GraphGraphicsView::handleAddCommonSuccessorToView);
                 if (isGate)
                 {
-                    action = preSucMenu->addAction("Add path to successor to view …");
-                    action->setData(true);
+                    action = preSucMenu->addAction("Add path to successor gate to view …");
+                    action->setData(SuccessorGate);
+                    connect(action, &QAction::triggered, this, &GraphGraphicsView::handleShortestPathToView);
+                    action = preSucMenu->addAction("Add path to successor module to view …");
+                    action->setData(SuccessorModule);
                     connect(action, &QAction::triggered, this, &GraphGraphicsView::handleShortestPathToView);
                 }
                 recursionLevelMenu(preSucMenu->addMenu("Highlight successors …"),             true, &GraphGraphicsView::handleHighlightSuccessor, true);
@@ -556,10 +559,10 @@ namespace hal
                 if (isGate)
                 {
                     action = preSucMenu->addAction("Highlight path to successor gate …");
-                    action->setData(true);
+                    action->setData(SuccessorGate);
                     connect(action, &QAction::triggered, this, &GraphGraphicsView::handleQueryShortestPathGate);
                     action = preSucMenu->addAction("Highlight path to successor module …");
-                    action->setData(true); // direction currently not used
+                    action->setData(SuccessorModule); // direction currently not used
                     connect(action, &QAction::triggered, this, &GraphGraphicsView::handleQueryShortestPathModule);
                 }
 
@@ -569,16 +572,16 @@ namespace hal
                     recursionLevelMenu(preSucMenu->addMenu("Add common predecessors to view …"),false, &GraphGraphicsView::handleAddCommonPredecessorToView);
                 if (isGate)
                 {
-                    action = preSucMenu->addAction("Add path to predecessor to view …");
-                    action->setData(false);
+                    action = preSucMenu->addAction("Add path to predecessor gate to view …");
+                    action->setData(PredecessorGate);
                     connect(action, &QAction::triggered, this, &GraphGraphicsView::handleShortestPathToView);
                 }
                 recursionLevelMenu(preSucMenu->addMenu("Highlight predecessors …"),             false, &GraphGraphicsView::handleHighlightPredecessor, true);
                 recursionLevelMenu(preSucMenu->addMenu("Highlight predecessors by distance …"), false, &GraphGraphicsView::handlePredecessorDistance);
                 if (isGate)
                 {
-                    action = preSucMenu->addAction("Highlight path to predecessor …");
-                    action->setData(false);
+                    action = preSucMenu->addAction("Highlight path to predecessor gate …");
+                    action->setData(PredecessorGate);
                     connect(action, &QAction::triggered, this, &GraphGraphicsView::handleQueryShortestPathGate);
                 }
             }
@@ -1116,41 +1119,71 @@ namespace hal
         gContentManager->getGroupingManagerWidget()->newGroupingByDistance(level,false,mItem);
     }
 
+    void GraphGraphicsView::handleShortestModulePathToView()
+    {
+
+    }
+
     void GraphGraphicsView::handleShortestPathToView()
     {
         QAction* send = static_cast<QAction*>(sender());
         Q_ASSERT(send);
-        bool succ = send->data().toBool();
 
-        QSet<u32> selectableGates;
-        Gate* gOrigin = gNetlist->get_gate_by_id(mItem->id());
-        Q_ASSERT(gOrigin);
-
-        for (Gate* g : netlist_utils::get_next_gates(gOrigin,succ))
-        {
-            selectableGates.insert(g->get_id());
-        }
-
-//        GraphGraphicsViewNeighborSelector* ggvns = new GraphGraphicsViewNeighborSelector(mItem->id(), succ, this);
-        GateDialog gd(selectableGates, QString("Shortest path %1 gate").arg(succ?"to":"from"), nullptr, this);
-
-        if (gd.exec() != QDialog::Accepted) return;
-
-        Gate* gTarget = gNetlist->get_gate_by_id(gd.selectedId());
-        Q_ASSERT(gTarget);
-
+        bool succ = true;
         std::vector<Gate*> spath;
-        if (succ)
-            spath = netlist_utils::get_shortest_path(gOrigin,gTarget);
+        Gate* startGate = gNetlist->get_gate_by_id(mItem->id());
+        Q_ASSERT(startGate);
+
+        if (send->data().toInt() == SuccessorModule)
+        {
+            QSet<u32> excludeModules;
+            const Module* parMod = startGate->get_module();
+            while (parMod)
+            {
+                excludeModules.insert(parMod->get_id());
+                parMod = parMod->get_parent_module();
+            }
+
+            ModuleDialog md(excludeModules, "Shortest path to module", true, nullptr, this);
+
+            if (md.exec() != QDialog::Accepted) return;
+
+            Module* endModule = gNetlist->get_module_by_id(md.selectedId());
+            Q_ASSERT(endModule);
+
+            spath = netlist_utils::get_shortest_path(startGate,endModule);
+        }
         else
         {
-            spath = netlist_utils::get_shortest_path(gTarget,gOrigin);
-            std::reverse(spath.begin(), spath.end());
+            succ = (send->data().toInt() == SuccessorGate);
+
+            QSet<u32> selectableGates;
+
+            for (Gate* g : netlist_utils::get_next_gates(startGate,succ))
+            {
+                selectableGates.insert(g->get_id());
+            }
+
+//        GraphGraphicsViewNeighborSelector* ggvns = new GraphGraphicsViewNeighborSelector(mItem->id(), succ, this);
+            GateDialog gd(selectableGates, QString("Shortest path %1 gate").arg(succ?"to":"from"), nullptr, this);
+
+            if (gd.exec() != QDialog::Accepted) return;
+
+            Gate* endGate = gNetlist->get_gate_by_id(gd.selectedId());
+            Q_ASSERT(endGate);
+
+            if (succ)
+                spath = netlist_utils::get_shortest_path(startGate,endGate);
+            else
+            {
+                spath = netlist_utils::get_shortest_path(endGate,startGate);
+                std::reverse(spath.begin(), spath.end());
+            }
         }
         if (spath.empty()) return;
         auto it = spath.begin() + 1;
         const NodeBoxes& boxes = mGraphWidget->getContext()->getLayouter()->boxes();
-        const NodeBox* lastBox = boxes.boxForGate(gOrigin);
+        const NodeBox* lastBox = boxes.boxForGate(startGate);
         Q_ASSERT(lastBox);
         QPoint point(lastBox->x(),lastBox->y());
         QPoint deltaX(succ ? 1 : -1, 0);
@@ -1171,7 +1204,7 @@ namespace hal
                     plc = PlacementHint(PlacementHint::GridPosition);
                 plc.addGridPosition(nd,point);
             }
-            gOrigin = g;
+            startGate = g;
         }
 
         ActionAddItemsToObject* act = new ActionAddItemsToObject({},gats);
@@ -1205,7 +1238,7 @@ namespace hal
     {
         QAction* send = static_cast<QAction*>(sender());
         Q_ASSERT(send);
-        bool succ = send->data().toBool();
+        bool succ = send->data().toInt() == SuccessorGate;
 
         QSet<u32> selectableGates;
         for (Gate* g : netlist_utils::get_next_gates(gNetlist->get_gate_by_id(mItem->id()),succ))
@@ -1246,7 +1279,7 @@ namespace hal
         {
             Module* m = gNetlist->get_module_by_id(nodeTo.id());
             Q_ASSERT(m);
-            spath = netlist_utils::get_shortest_path_to_module(g0,m);
+            spath = netlist_utils::get_shortest_path(g0,m);
             target = QString("module '%1'[%2]").arg(QString::fromStdString(m->get_name()), m->get_id());
         }
 

--- a/plugins/gui/src/graph_widget/graphics_qss_adapter.cpp
+++ b/plugins/gui/src/graph_widget/graphics_qss_adapter.cpp
@@ -40,8 +40,7 @@ namespace hal
         s->polish(this);
 
         ModuleShader::debugSetNetColor(mNetBaseColor);
-        StandardGraphicsGate::sTextColor = mNodeTextColor;
-        StandardGraphicsModule::sTextColor = mNodeTextColor;
+        GraphicsNode::sTextColor = mNodeTextColor;
     }
 
     void GraphicsQssAdapter::setGridAlpha(int alpha)

--- a/plugins/gui/src/graph_widget/items/nodes/gates/graphics_gate.cpp
+++ b/plugins/gui/src/graph_widget/items/nodes/gates/graphics_gate.cpp
@@ -7,7 +7,8 @@ namespace hal
 {
     GraphicsGate::GraphicsGate(Gate* g) : GraphicsNode(ItemType::Gate, g->get_id()), mGate(g), mType(QString::fromStdString(g->get_type()->get_name()))
     {
-        mNodeText[0] = QString::fromStdString(g->get_name());
+        QString textLines[3];
+        textLines[0] = QString::fromStdString(g->get_name());
         const GateType* gt = g->get_type();
         for (const GatePin* input_pin : gt->get_input_pins())
         {
@@ -37,6 +38,7 @@ namespace hal
             mOutputPins.append(QString::fromStdString(output_pin->get_name()));
         }
 
-        mNodeText[1] = QString::fromStdString(gt->get_name());
+        textLines[1] = QString::fromStdString(gt->get_name());
+        setNodeText(textLines,true);
     }
 }    // namespace hal

--- a/plugins/gui/src/graph_widget/items/nodes/gates/graphics_gate.cpp
+++ b/plugins/gui/src/graph_widget/items/nodes/gates/graphics_gate.cpp
@@ -5,8 +5,9 @@
 
 namespace hal
 {
-    GraphicsGate::GraphicsGate(Gate* g) : GraphicsNode(ItemType::Gate, g->get_id(), QString::fromStdString(g->get_name())), mGate(g), mType(QString::fromStdString(g->get_type()->get_name()))
+    GraphicsGate::GraphicsGate(Gate* g) : GraphicsNode(ItemType::Gate, g->get_id()), mGate(g), mType(QString::fromStdString(g->get_type()->get_name()))
     {
+        mNodeText[0] = QString::fromStdString(g->get_name());
         const GateType* gt = g->get_type();
         for (const GatePin* input_pin : gt->get_input_pins())
         {

--- a/plugins/gui/src/graph_widget/items/nodes/graphics_node.cpp
+++ b/plugins/gui/src/graph_widget/items/nodes/graphics_node.cpp
@@ -6,10 +6,9 @@
 
 namespace hal
 {
-    GraphicsNode::GraphicsNode(const ItemType type, const u32 id, const QString& name)
+    GraphicsNode::GraphicsNode(const ItemType type, const u32 id)
         : GraphicsItem(type, id)
     {
-        mNodeText[0] = name;
         setFlags(QGraphicsItem::ItemIsSelectable | QGraphicsItem::ItemSendsGeometryChanges);
         //setFlags(QGraphicsItem::ItemIsSelectable | QGraphicsItem::ItemIsMovable | QGraphicsItem::ItemSendsGeometryChanges | ItemIsFocusable);
         //setAcceptHoverEvents(true);

--- a/plugins/gui/src/graph_widget/items/nodes/modules/graphics_module.cpp
+++ b/plugins/gui/src/graph_widget/items/nodes/modules/graphics_module.cpp
@@ -9,7 +9,7 @@ namespace hal
 {
     GraphicsModule::GraphicsModule(Module* m) : GraphicsNode(ItemType::Module, m->get_id())
     {
-        setModuleLabel(m);
+        setModuleLabel(m, true);
 
         for (hal::ModulePin* pin : m->get_pins())
         {
@@ -38,10 +38,12 @@ namespace hal
         }
     }
 
-    void GraphicsModule::setModuleLabel(const Module* m)
+    void GraphicsModule::setModuleLabel(const Module* m, bool init)
     {
-        mNodeText[0]                              = QString::fromStdString(m->get_name());
-        mNodeText[1]                              = QString::fromStdString(m->get_type());
-        mNodeText[mNodeText[1].isEmpty() ? 1 : 2] = "Module";
+        QString textLines[3];
+        textLines[0]                              = QString::fromStdString(m->get_name());
+        textLines[1]                              = QString::fromStdString(m->get_type());
+        textLines[textLines[1].isEmpty() ? 1 : 2] = "Module";
+        setNodeText(textLines,init);
     }
 }    // namespace hal

--- a/plugins/gui/src/graph_widget/items/nodes/modules/graphics_module.cpp
+++ b/plugins/gui/src/graph_widget/items/nodes/modules/graphics_module.cpp
@@ -7,10 +7,9 @@
 
 namespace hal
 {
-    GraphicsModule::GraphicsModule(Module* m) : GraphicsNode(ItemType::Module, m->get_id(), QString::fromStdString(m->get_name()))
+    GraphicsModule::GraphicsModule(Module* m) : GraphicsNode(ItemType::Module, m->get_id())
     {
-        mNodeText[1]                              = QString::fromStdString(m->get_type());
-        mNodeText[mNodeText[1].isEmpty() ? 1 : 2] = "Module";
+        setModuleLabel(m);
 
         for (hal::ModulePin* pin : m->get_pins())
         {
@@ -37,5 +36,12 @@ namespace hal
                     break;
             }
         }
+    }
+
+    void GraphicsModule::setModuleLabel(const Module* m)
+    {
+        mNodeText[0]                              = QString::fromStdString(m->get_name());
+        mNodeText[1]                              = QString::fromStdString(m->get_type());
+        mNodeText[mNodeText[1].isEmpty() ? 1 : 2] = "Module";
     }
 }    // namespace hal

--- a/plugins/gui/src/graph_widget/items/nodes/modules/standard_graphics_module.cpp
+++ b/plugins/gui/src/graph_widget/items/nodes/modules/standard_graphics_module.cpp
@@ -6,8 +6,6 @@
 #include "gui/gui_utils/graphics.h"
 #include "hal_core/netlist/gate.h"
 
-#include <QFont>
-#include <QFontMetricsF>
 #include <QImage>
 #include <QPainter>
 #include <QPen>
@@ -22,12 +20,7 @@ namespace hal
 
     QPen StandardGraphicsModule::sPen;
 
-    QColor StandardGraphicsModule::sTextColor;
-
-    QFont StandardGraphicsModule::sTextFont[3];
     QFont StandardGraphicsModule::sPinFont;
-
-    qreal StandardGraphicsModule::sTextFontHeight[3] = {0, 0, 0};
 
     qreal StandardGraphicsModule::sColorBarHeight = 30;
 
@@ -67,13 +60,6 @@ namespace hal
 
         QFont font = QFont("Iosevka");
         font.setPixelSize(graph_widget_constants::sFontSize);
-
-        for (int iline = 0; iline < 3; iline++)
-        {
-            sTextFont[iline] = font;
-            QFontMetricsF fmf(font);
-            sTextFontHeight[iline] = fmf.height();
-        }
 
         sPinFont = font;
 
@@ -243,13 +229,6 @@ namespace hal
 
     void StandardGraphicsModule::format(const bool& adjust_size_to_grid)
     {
-        qreal textWidth[3] = {0, 0, 0};
-        for (int iline = 0; iline < 3; iline++)
-        {
-            QFontMetricsF fmf(sTextFont[iline]);
-            textWidth[iline] = fmf.width(mNodeText[iline]);
-        }
-
         QFontMetricsF pin_fm(sPinFont);
         qreal max_pin_width = 0;
 
@@ -280,16 +259,12 @@ namespace hal
 
         qreal max_pin_height  = std::max(total_input_pin_height, total_output_pin_height);
         qreal min_body_height = sInnerNameTypeSpacing + 2 * sOuterNameTypeSpacing;
-        qreal maxTextWidth    = 0;
         for (int iline = 0; iline < 3; iline++)
         {
-            if (iline != 2 || !mNodeText[iline].isEmpty())
-                min_body_height += sTextFontHeight[iline];
-            if (maxTextWidth < textWidth[iline])
-                maxTextWidth = textWidth[iline];
+            min_body_height += sTextFontHeight[iline];
         }
 
-        mWidth  = max_pin_width * 2 + sPinInnerHorizontalSpacing * 2 + sPinOuterHorizontalSpacing * 2 + maxTextWidth;
+        mWidth  = max_pin_width * 2 + sPinInnerHorizontalSpacing * 2 + sPinOuterHorizontalSpacing * 2 + mMaxTextWidth;
         mHeight = std::max(max_pin_height, min_body_height) + sColorBarHeight;
 
         if (adjust_size_to_grid)
@@ -309,13 +284,7 @@ namespace hal
 
         qreal ytext = std::max(mHeight / 2 - sTextFontHeight[0] * 3 / 2 - sInnerNameTypeSpacing / 2, sColorBarHeight + sOuterNameTypeSpacing);
 
-        for (int iline = 0; iline < 3; iline++)
-        {
-            ytext += sTextFontHeight[iline];
-            mTextPosition[iline].setX(mWidth / 2 - textWidth[iline] / 2);
-            mTextPosition[iline].setY(ytext);
-            ytext += sInnerNameTypeSpacing / 2;
-        }
+        initTextPosition(ytext, sInnerNameTypeSpacing);
 
         qreal y = sColorBarHeight + sPinUpperVerticalSpacing + sPinFontAscent + sBaseline;
 

--- a/plugins/gui/src/graph_widget/layouters/graph_layouter.cpp
+++ b/plugins/gui/src/graph_widget/layouters/graph_layouter.cpp
@@ -107,6 +107,29 @@ namespace hal
         return mPositionToNodeMap;
     }
 
+    void GraphLayouter::updatePlacement(const GridPlacement& plc)
+    {
+        // Keep track which positions are occupied by new nodes, possible values:
+        // -1 : position no longer occupied
+        //  1 : position which was not occupied before now occupied
+        //  0 : old position taken by new node
+        QHash<QPoint,int> positionOccupied;
+
+        for (auto it = plc.constBegin(); it != plc.constEnd(); ++it)
+        {
+            auto jt = mNodeToPositionMap.find(it.key());
+            if (jt == mNodeToPositionMap.end()) continue;
+            --positionOccupied[jt.value()];  // old value from mNodePositionMap
+            ++positionOccupied[it.value()];  // new value from plc
+            jt.value() = it.value();
+            mPositionToNodeMap[it.value()] = it.key();
+        }
+
+        for (auto rpit = positionOccupied.begin(); rpit != positionOccupied.end(); ++rpit)
+            if (rpit.value() < 0)
+                mPositionToNodeMap.remove(rpit.key());
+    }
+
     void GraphLayouter::setNodePosition(const Node& n, const QPoint& p)
     {
         if (mNodeToPositionMap.contains(n))

--- a/plugins/gui/src/module_model/module_model.cpp
+++ b/plugins/gui/src/module_model/module_model.cpp
@@ -17,6 +17,7 @@ namespace hal
         setHeaderLabels(QStringList() << "Name" << "ID" << "Type");
         connect(gNetlistRelay, &NetlistRelay::moduleCreated,          this, &ModuleModel::handleModuleCreated);
         connect(gNetlistRelay, &NetlistRelay::moduleNameChanged,      this, &ModuleModel::handleModuleNameChanged);
+        connect(gNetlistRelay, &NetlistRelay::moduleTypeChanged,      this, &ModuleModel::handleModuleTypeChanged);
         connect(gNetlistRelay, &NetlistRelay::moduleParentChanged,    this, &ModuleModel::handleModuleParentChanged);
         connect(gNetlistRelay, &NetlistRelay::moduleSubmoduleAdded,   this, &ModuleModel::handleModuleSubmoduleAdded);
         connect(gNetlistRelay, &NetlistRelay::moduleSubmoduleRemoved, this, &ModuleModel::handleModuleSubmoduleRemoved);
@@ -367,6 +368,11 @@ namespace hal
     void ModuleModel::handleModuleNameChanged(Module* mod)
     {
         updateModuleName(mod->get_id());
+    }
+
+    void ModuleModel::handleModuleTypeChanged(Module* mod)
+    {
+        updateModuleType(mod->get_id());
     }
 
     void ModuleModel::handleModuleRemoved(Module* mod)
@@ -786,7 +792,23 @@ namespace hal
             ModuleItem* item = it.value();
             Q_ASSERT(item);
 
-            item->setName(QString::fromStdString(gNetlist->get_module_by_id(id)->get_name()));    // REMOVE & ADD AGAIN
+            item->setName(QString::fromStdString(gNetlist->get_module_by_id(id)->get_name()));
+
+            QModelIndex index = getIndexFromItem(item);
+            Q_EMIT dataChanged(index, index);
+        }
+    }
+
+    void ModuleModel::updateModuleType(u32 id)
+    {
+        Q_ASSERT(gNetlist->get_module_by_id(id));
+
+        for (auto it = mModuleMap.lowerBound(id); it != mModuleMap.upperBound(id); ++it)
+        {
+            ModuleItem* item = it.value();
+            Q_ASSERT(item);
+
+            item->setModuleType(QString::fromStdString(gNetlist->get_module_by_id(id)->get_type()));
 
             QModelIndex index = getIndexFromItem(item);
             Q_EMIT dataChanged(index, index);

--- a/plugins/gui/src/style/style.cpp
+++ b/plugins/gui/src/style/style.cpp
@@ -28,6 +28,7 @@ namespace hal
         void debugUpdate()
         {
             GraphicsItem::loadSettings();
+            GraphicsNode::loadSettings();
             StandardGraphicsModule::loadSettings();
             StandardGraphicsGate::loadSettings();
             GraphicsNet::loadSettings();

--- a/plugins/gui/src/user_action/action_move_node.cpp
+++ b/plugins/gui/src/user_action/action_move_node.cpp
@@ -160,18 +160,7 @@ namespace hal
         }
 
         LayoutLocker llock;
-        ctx->clear();
-
-        QSet<u32> modIds;
-        QSet<u32> gateIds;
-
-        for (Node node : mGridPlacement.keys())
-        {
-            if(node.isModule()) modIds.insert(node.id());
-            else gateIds.insert(node.id());
-        }
-
-        ctx->add(modIds, gateIds, PlacementHint(mGridPlacement));
+        ctx->updatePlacement(mGridPlacement);
         ctx->scheduleSceneUpdate();
 
         return UserAction::exec();

--- a/src/netlist/netlist_utils.cpp
+++ b/src/netlist/netlist_utils.cpp
@@ -19,16 +19,26 @@ namespace hal
     {
         namespace
         {
-            // Might be unified
-            std::vector<Gate*> get_shortest_path_to_module_internal(Gate* start_gate, Module* end_module)
+
+            std::vector<Gate*> get_shortest_path_internal(Gate* start_gate, const std::unordered_set<Gate*>& end_gates)
             {
-                std::unordered_set<Gate*> end_gates;
-                for (Gate* g : end_module->get_gates(nullptr, true))
-                {
-                    end_gates.insert(g);
-                }
-                if (end_gates.find(start_gate) != end_gates.end())
+                if (end_gates.empty())
                     return std::vector<Gate*>();
+
+                Gate* end_gate_single = *(end_gates.begin());
+
+                auto heurekaSingle = [end_gate_single] (Gate* test_gate) { return test_gate==end_gate_single; } ;
+
+                auto heurekaMultiple = [end_gates] (Gate* test_gate) { return end_gates.find(test_gate) != end_gates.end(); } ;
+
+                auto heureka = [heurekaSingle, heurekaMultiple, end_gates] (Gate* test_gate) {
+                    if (end_gates.size() > 1)
+                        return heurekaMultiple(test_gate);
+                    return heurekaSingle(test_gate);} ;
+
+                if (heureka(start_gate))
+                    return std::vector<Gate*>();
+
                 std::vector<Gate*> v0;
                 v0.push_back(start_gate);
                 std::unordered_map<Gate*, Gate*> originMap;
@@ -43,53 +53,11 @@ namespace hal
                                 continue;    // already routed to
                             v1.push_back(g1);
                             originMap[g1] = g0;
-                            if (end_gates.find(g1) != end_gates.end())
+                            if (heureka(g1))
                             {
                                 // heureka!
                                 std::vector<Gate*> retval;
                                 Gate* g = g1;
-                                while (g != start_gate)
-                                {
-                                    retval.insert(retval.begin(), g);
-                                    auto it = originMap.find(g);
-                                    assert(it != originMap.end());
-                                    g = it->second;
-                                }
-                                retval.insert(retval.begin(), start_gate);
-                                return retval;
-                            }
-                        }
-                    }
-                    if (v1.empty())
-                        break;
-                    v0 = v1;
-                }
-                return std::vector<Gate*>();
-            }
-
-            std::vector<Gate*> get_shortest_path_internal(Gate* start_gate, Gate* end_gate)
-            {
-                if (start_gate == end_gate)
-                    return std::vector<Gate*>();
-                std::vector<Gate*> v0;
-                v0.push_back(start_gate);
-                std::unordered_map<Gate*, Gate*> originMap;
-                for (;;)
-                {
-                    std::vector<Gate*> v1;
-                    for (Gate* g0 : v0)
-                    {
-                        for (Gate* g1 : get_next_gates(g0, true, 1))
-                        {
-                            if (originMap.find(g1) != originMap.end())
-                                continue;    // already routed to
-                            v1.push_back(g1);
-                            originMap[g1] = g0;
-                            if (g1 == end_gate)
-                            {
-                                // heureka!
-                                std::vector<Gate*> retval;
-                                Gate* g = end_gate;
                                 while (g != start_gate)
                                 {
                                     retval.insert(retval.begin(), g);
@@ -316,17 +284,26 @@ namespace hal
             return retval;
         }
 
-        std::vector<Gate*> get_shortest_path_to_module(Gate* start_gate, Module* end_module)
+        std::vector<Gate*> get_shortest_path(Gate* start_gate, Module* end_module)
         {
-            return get_shortest_path_to_module_internal(start_gate, end_module);
+            std::unordered_set<Gate*> end_gates;
+            for (Gate* g : end_module->get_gates(nullptr, true))
+            {
+                end_gates.insert(g);
+            }
+            return get_shortest_path_internal(start_gate, end_gates);
         }
 
         std::vector<Gate*> get_shortest_path(Gate* start_gate, Gate* end_gate, bool search_both_directions)
         {
-            std::vector<Gate*> path_forward = get_shortest_path_internal(start_gate, end_gate);
+            std::unordered_set<Gate*> end_gates_forward;
+            end_gates_forward.insert(end_gate);
+            std::vector<Gate*> path_forward = get_shortest_path_internal(start_gate, end_gates_forward);
             if (!search_both_directions)
                 return path_forward;
-            std::vector<Gate*> path_reverse = get_shortest_path_internal(end_gate, start_gate);
+            std::unordered_set<Gate*> start_gates_reverse;
+            start_gates_reverse.insert(start_gate);
+            std::vector<Gate*> path_reverse = get_shortest_path_internal(end_gate, start_gates_reverse);
             return (path_reverse.size() < path_forward.size()) ? path_reverse : path_forward;
         }
 

--- a/src/python_bindings/bindings/netlist_utils.cpp
+++ b/src/python_bindings/bindings/netlist_utils.cpp
@@ -391,14 +391,25 @@ namespace hal
             :rtype: list[hal_py.Gate]
         )");
 
-        py_netlist_utils.def("get_shortest_path", &netlist_utils::get_shortest_path, py::arg("start_gate"), py::arg("end_gate"), py::arg("search_both_directions") = false, R"(
+        py_netlist_utils.def("get_shortest_path", py::overload_cast<Gate*,Gate*,bool>(&netlist_utils::get_shortest_path), py::arg("start_gate"), py::arg("end_gate"), py::arg("search_both_directions") = false, R"(
             Find the shortest path (i.e., theresult set with the lowest number of gates) that connects the start gate with the end gate. 
             The gate where the search started from will be the first in the result vector, the end gate will be the last. 
             If there is no such path an empty vector is returned. If there is more than one path with the same length only the first one is returned.
 
-            :param dict[hal_py.GateType,list[hal_py.GatePin]] input_pins: The input pins (of every gate type of the sequence) through which the gates must be connected.
-            :param dict[hal_py.GateType,list[hal_py.GatePin]] output_pins: The output pins (of every gate type of the sequence) through which the gates must be connected.
-            :param lambda filter: An optional filter function to be evaluated on each gate.
+            :param hal_py.Gate start_gate: The start gate for the path (might be the end if searching both directions)
+            :param hal_py.Gate end_gate: The end gate for the path (might be the start if searching both directions)
+            :bool search_both_directions: If true checking start <-> end, which ever direction is shorter
+            :returns: A list of gates that form a chain on success, an empty list on error.
+            :rtype: list[hal_py.Gate]
+        )");
+
+        py_netlist_utils.def("get_shortest_path", py::overload_cast<Gate*,Module*>(&netlist_utils::get_shortest_path), py::arg("start_gate"), py::arg("end_module"), R"(
+            Find the shortest path (i.e., theresult set with the lowest number of gates) that connects the start gate with any gate for the given module.
+            The gate where the search started from will be the first in the result vector, the end gate will be the last.
+            If there is no such path an empty vector is returned. If there is more than one path with the same length only the first one is returned.
+
+            :param hal_py.Gate start_gate: The start gate for the path
+            :param hal_py.Module end_module: The module which contains the end gate for the path
             :returns: A list of gates that form a chain on success, an empty list on error.
             :rtype: list[hal_py.Gate]
         )");


### PR DESCRIPTION
1. Extend GUI function "shortest path to successor" so that a module can be selected as endpoint of path
2. No more call to layout() function upon module rename, type change or color change on default. The old behavior is still available and can be selected via user setting. 
3. Bugfix in module tree : the change module type signal was not handled
