### PR TITLE
Add New Delay Gate Type Property

### DIFF
--- a/include/hal_core/netlist/gate_library/enums/gate_type_property.h
+++ b/include/hal_core/netlist/gate_library/enums/gate_type_property.h
@@ -47,6 +47,7 @@ namespace hal
         pll,            /**< PLL gate type. **/
         oscillator,     /**< Oscillator gate type. **/
         scan,           /**< Scan gate type. **/
+        delay,          /**< Delay gate type. **/
         c_buffer,       /**< Buffer gate type. **/
         c_inverter,     /**< Inverter gate type. **/
         c_and,          /**< AND gate type. **/

--- a/src/netlist/gate_library/enums/gate_type_property.cpp
+++ b/src/netlist/gate_library/enums/gate_type_property.cpp
@@ -18,6 +18,7 @@ namespace hal
                                                                                    {GateTypeProperty::pll, "pll"},
                                                                                    {GateTypeProperty::oscillator, "oscillator"},
                                                                                    {GateTypeProperty::scan, "scan"},
+                                                                                   {GateTypeProperty::delay, "delay"},
                                                                                    {GateTypeProperty::c_buffer, "c_buffer"},
                                                                                    {GateTypeProperty::c_inverter, "c_inverter"},
                                                                                    {GateTypeProperty::c_and, "c_and"},


### PR DESCRIPTION
ASICs often include dedicated delay cells whose primary purpose is to introduce a controlled delay to a signal, for example, within clock distribution networks. To accurately represent these gates, I propose adding this property.