### PR TITLE
Fix igraph_t ownership issues in NetlistGraph

### DIFF
--- a/plugins/graph_algorithm/include/graph_algorithm/netlist_graph.h
+++ b/plugins/graph_algorithm/include/graph_algorithm/netlist_graph.h
@@ -92,10 +92,23 @@ namespace hal
              */
             NetlistGraph(Netlist* nl, igraph_t&& graph, std::unordered_map<u32, Gate*>&& nodes_to_gates);
 
-            /** 
+            /**
              * @brief Default destructor for `NetlistGraph`.
              */
             ~NetlistGraph();
+
+            /**
+             * `igraph_t` is a plain C struct holding heap pointers, so the implicitly generated copy
+             * operations would bitwise-copy `m_graph` and leave two `NetlistGraph` objects aliasing the
+             * same graph internals -- the destructor would then call `igraph_destroy()` on them twice, and
+             * the copy's `m_graph_ptr` would still point into the source object. Every factory hands out a
+             * `std::unique_ptr<NetlistGraph>`, so nothing is meant to copy a graph in the first place;
+             * deleting the copy operations makes that invariant explicit and enforced at compile time
+             * instead of relying on convention.
+             */
+            NetlistGraph(const NetlistGraph&) = delete;
+
+            NetlistGraph& operator=(const NetlistGraph&) = delete;
 
             /**
              * @brief Create a directed graph from a netlist. 
@@ -353,9 +366,20 @@ namespace hal
             igraph_t m_graph;
 
             /**
+             * Whether `m_graph` has actually been initialized and therefore has to be destroyed.
+             *
+             * The `NetlistGraph(Netlist*)` constructor deliberately leaves `m_graph` uninitialized -- the
+             * factories fill it in afterwards via `igraph_create()`/`igraph_empty()`. If such a factory bails
+             * out in between (e.g. an igraph allocation fails), the `std::unique_ptr` holding the
+             * half-constructed graph unwinds and the destructor would otherwise call `igraph_destroy()` on
+             * uninitialized memory. This flag lets the destructor skip that.
+             */
+            bool m_graph_initialized = false;
+
+            /**
              * A pointer to the `igraph` object.
              */
-            igraph_t* m_graph_ptr;
+            igraph_t* m_graph_ptr = nullptr;
 
             /**
              * A map from `igraph` nodes to HAL gates.

--- a/plugins/graph_algorithm/src/netlist_graph.cpp
+++ b/plugins/graph_algorithm/src/netlist_graph.cpp
@@ -16,7 +16,11 @@ namespace hal
 
         NetlistGraph::NetlistGraph(Netlist* nl, igraph_t&& graph, std::unordered_map<u32, Gate*>&& nodes_to_gates) : m_nl(nl), m_graph(std::move(graph)), m_nodes_to_gates(std::move(nodes_to_gates))
         {
-            m_graph_ptr = &m_graph;
+            // This constructor receives an already-initialized graph and takes over its ownership. Note that
+            // `igraph_t` is a trivially copyable C struct, so the `std::move()` above is a bitwise copy and the
+            // caller's object is left holding the same pointers -- the caller must therefore not destroy it.
+            m_graph_initialized = true;
+            m_graph_ptr         = &m_graph;
 
             for (const auto& [node, gate] : m_nodes_to_gates)
             {
@@ -29,7 +33,12 @@ namespace hal
 
         NetlistGraph::~NetlistGraph()
         {
-            igraph_destroy(&m_graph);
+            // Guarded because the `NetlistGraph(Netlist*)` constructor leaves `m_graph` uninitialized and a
+            // factory may bail out before initializing it -- see `m_graph_initialized`.
+            if (m_graph_initialized)
+            {
+                igraph_destroy(&m_graph);
+            }
         }
 
         Result<std::unique_ptr<NetlistGraph>> NetlistGraph::from_netlist(Netlist* nl, bool create_dummy_vertices, const std::function<bool(const Net*)>& filter)
@@ -154,6 +163,8 @@ namespace hal
                 return ERR(igraph_strerror(err));
             }
 
+            graph->m_graph_initialized = true;
+
             return OK(std::move(graph));
         }
 
@@ -183,6 +194,8 @@ namespace hal
                 return ERR(igraph_strerror(err));
             }
 
+            graph->m_graph_initialized = true;
+
             return OK(std::move(graph));
         }
 
@@ -195,9 +208,10 @@ namespace hal
                 return ERR(igraph_strerror(res));
             }
 
-            graph->m_graph_ptr      = &(graph->m_graph);
-            graph->m_gates_to_nodes = this->m_gates_to_nodes;
-            graph->m_nodes_to_gates = this->m_nodes_to_gates;
+            graph->m_graph_initialized = true;
+            graph->m_graph_ptr         = &(graph->m_graph);
+            graph->m_gates_to_nodes    = this->m_gates_to_nodes;
+            graph->m_nodes_to_gates    = this->m_nodes_to_gates;
 
             return OK(std::move(graph));
         }


### PR DESCRIPTION
Two related memory-safety defects around NetlistGraph's igraph_t member.

1. Destroying an uninitialized igraph_t.

   NetlistGraph(Netlist*) initializes only m_nl, deliberately leaving m_graph to be filled in afterwards by the factory that called it (igraph_create() in from_netlist(), igraph_empty() in from_netlist_no_edges(), igraph_copy() in copy()). The destructor, however, called igraph_destroy(&m_graph) unconditionally.

   When a factory bails out between construction and that initialization, the std::unique_ptr holding the half-constructed graph unwinds and igraph_destroy() runs over uninitialized memory. Reachable paths:

     - from_netlist(): constructed at the top, returns early if igraph_vector_int_init() for the edge vector fails, well before igraph_create() is reached.
     - copy(): constructed at the top, returns early if igraph_copy() itself fails.

   Both require an igraph allocation to fail, so this does not show up in
   normal runs, but it is a genuine crash path rather than a leak.

   Fixed by tracking whether m_graph was actually initialized and having
   the destructor honour that. The flag is set only after the respective
   igraph call has reported success. m_graph_ptr is now default-initialized
   to nullptr as well, since the same constructor left it dangling.

2. NetlistGraph was implicitly copyable.

   igraph_t is a plain C struct holding heap pointers, so the implicitly generated copy constructor and copy assignment operator bitwise-copied m_graph and left two NetlistGraph objects aliasing the same graph internals; the destructor would then igraph_destroy() them twice. The copy's m_graph_ptr would additionally point into the source object.

   Nothing copies a NetlistGraph today -- every factory hands out a std::unique_ptr<NetlistGraph>, the python bindings hold it via RawPtrWrapper and pass it by const reference, and callers wanting a duplicate use the explicit copy() method -- so this was latent. Deleting the copy operations enforces that invariant at compile time instead of leaving it to convention.

Verified by syntax-checking all 14 translation units under plugins/graph_algorithm and plugins/hawkeye (including both python binding files) against the modified header; all compile unchanged. Both files are clang-format clean.